### PR TITLE
Redesign site with "Still Root" calm portfolio aesthetic

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,8 @@
       "devDependencies": {
         "@eslint/compat": "^2.0.3",
         "@eslint/js": "^9.39.2",
+        "@fontsource-variable/jetbrains-mono": "^5.2.8",
+        "@fontsource-variable/literata": "^5.2.8",
         "@fontsource/fira-mono": "^5.2.7",
         "@neoconfetti/svelte": "^2.2.2",
         "@skeletonlabs/skeleton": "4.13.0",
@@ -180,6 +182,10 @@
     "@floating-ui/dom": ["@floating-ui/dom@1.7.5", "", { "dependencies": { "@floating-ui/core": "^1.7.4", "@floating-ui/utils": "^0.2.10" } }, "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
+
+    "@fontsource-variable/jetbrains-mono": ["@fontsource-variable/jetbrains-mono@5.2.8", "", {}, "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q=="],
+
+    "@fontsource-variable/literata": ["@fontsource-variable/literata@5.2.8", "", {}, "sha512-LhxHyo0lDNu2w8FJ7OfTZl6kT8pDYhXiCmWxFAqpUmOqHz1z3OWOaaWBDVOCDOE8b+GWJQX9HYHZ2CERQjjlWA=="],
 
     "@fontsource/fira-mono": ["@fontsource/fira-mono@5.2.7", "", {}, "sha512-wYrAn6i3nH6luqQBZxtWUpl4UTUvs9AEbEeZxksPMwIqyjRRaxHTNW3c2VfM50gabS2IS7pT8lVWS2USB4ukYA=="],
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "devDependencies": {
     "@eslint/compat": "^2.0.3",
     "@eslint/js": "^9.39.2",
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
+    "@fontsource-variable/literata": "^5.2.8",
     "@fontsource/fira-mono": "^5.2.7",
     "@neoconfetti/svelte": "^2.2.2",
     "@skeletonlabs/skeleton": "4.13.0",

--- a/src/app.css
+++ b/src/app.css
@@ -41,15 +41,6 @@ a:hover {
   text-decoration-color: oklch(62% 0.08 155 / 0.8);
 }
 
-@variant dark {
-  a {
-    text-decoration-color: oklch(62% 0.08 155 / 0.3);
-  }
-  a:hover {
-    text-decoration-color: oklch(62% 0.08 155 / 0.8);
-  }
-}
-
 /* Nav links: no underline by default */
 .nav-link {
   text-decoration: none;
@@ -57,12 +48,12 @@ a:hover {
 }
 .nav-link:hover {
   text-decoration: none;
-  color: oklch(40% 0.1 155);
+  color: light-dark(oklch(40% 0.1 155), oklch(62% 0.08 155));
 }
-@variant dark {
-  .nav-link:hover {
-    color: oklch(62% 0.08 155);
-  }
+
+/* Site name color: sage, adapts to mode */
+.site-name {
+  color: light-dark(oklch(40% 0.1 155), oklch(62% 0.08 155));
 }
 
 /* --- Shiki dual-theme support --- */
@@ -236,12 +227,10 @@ code {
 
 /* Inline code tinted with sage */
 :not(pre) > code {
-  background-color: color-mix(in oklab, oklch(58% 0.08 155) 8%, oklch(97% 0.01 140));
-}
-@variant dark {
-  :not(pre) > code {
-    background-color: color-mix(in oklab, oklch(58% 0.08 155) 8%, oklch(14% 0.015 160));
-  }
+  background-color: light-dark(
+    color-mix(in oklab, oklch(58% 0.08 155) 8%, oklch(97% 0.01 140)),
+    color-mix(in oklab, oklch(58% 0.08 155) 8%, oklch(14% 0.015 160))
+  );
 }
 
 /* --- Blockquotes: a memory surfacing --- */
@@ -262,19 +251,14 @@ blockquote {
   line-height: 0.8;
   padding-right: 0.12em;
   padding-top: 0.08em;
-  color: oklch(40% 0.1 155);
-}
-@variant dark {
-  .prose > p:first-of-type::first-letter {
-    color: oklch(62% 0.08 155);
-  }
+  color: light-dark(oklch(40% 0.1 155), oklch(62% 0.08 155));
 }
 
 /* --- The :wq signoff --- */
 .signoff {
   font-family: var(--font-mono);
   font-size: 0.875rem;
-  color: oklch(45% 0.01 80);
+  color: light-dark(oklch(45% 0.01 80), oklch(55% 0.015 80));
   text-align: right;
   text-decoration: none;
 }
@@ -283,11 +267,6 @@ blockquote {
   animation: blink 1.2s step-end infinite;
   opacity: 0.4;
   margin-left: 0.15em;
-}
-@variant dark {
-  .signoff {
-    color: oklch(55% 0.015 80);
-  }
 }
 
 @keyframes blink {
@@ -302,24 +281,14 @@ blockquote {
 
 /* --- Prose overrides for the editorial feel --- */
 .prose {
-  --tw-prose-body: oklch(20% 0.01 160);
-  --tw-prose-headings: oklch(15% 0.015 160);
-  --tw-prose-links: oklch(40% 0.1 155);
-  --tw-prose-bold: oklch(15% 0.015 160);
-  --tw-prose-quotes: oklch(30% 0.01 160);
+  --tw-prose-body: light-dark(oklch(20% 0.01 160), oklch(90% 0.02 80));
+  --tw-prose-headings: light-dark(oklch(15% 0.015 160), oklch(93% 0.015 80));
+  --tw-prose-links: light-dark(oklch(40% 0.1 155), oklch(62% 0.08 155));
+  --tw-prose-bold: light-dark(oklch(15% 0.015 160), oklch(93% 0.015 80));
+  --tw-prose-quotes: light-dark(oklch(30% 0.01 160), oklch(80% 0.015 80));
   --tw-prose-quote-borders: oklch(62% 0.08 155 / 0.4);
-  --tw-prose-code: oklch(30% 0.01 160);
-  --tw-prose-hr: oklch(87% 0.012 155);
-}
-.prose.dark\:prose-invert:where([data-mode='dark'], .dark *) {
-  --tw-prose-body: oklch(90% 0.02 80);
-  --tw-prose-headings: oklch(93% 0.015 80);
-  --tw-prose-links: oklch(62% 0.08 155);
-  --tw-prose-bold: oklch(93% 0.015 80);
-  --tw-prose-quotes: oklch(80% 0.015 80);
-  --tw-prose-quote-borders: oklch(62% 0.08 155 / 0.4);
-  --tw-prose-code: oklch(85% 0.015 80);
-  --tw-prose-hr: oklch(26% 0.012 160);
+  --tw-prose-code: light-dark(oklch(30% 0.01 160), oklch(85% 0.015 80));
+  --tw-prose-hr: light-dark(oklch(87% 0.012 155), oklch(26% 0.012 160));
 }
 
 /* --- Subtle top glow --- */

--- a/src/app.css
+++ b/src/app.css
@@ -2,26 +2,70 @@
 @import '@skeletonlabs/skeleton';
 @import '@skeletonlabs/skeleton-svelte';
 @import '@skeletonlabs/skeleton/themes/catppuccin';
-@import './espresso.css'; /* Custom Themes */
-@import '@fontsource/fira-mono';
+@import './espresso.css'; /* Custom Theme */
+@import '@fontsource-variable/literata';
+@import '@fontsource-variable/jetbrains-mono';
 
 @plugin '@tailwindcss/forms';
 @plugin '@tailwindcss/typography';
 
 :root {
-  --font-body:
-    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
-    'Helvetica Neue', sans-serif;
-  --font-mono: 'Fira Mono', monospace;
+  --font-serif: 'Literata Variable', 'Literata', Georgia, 'Times New Roman', serif;
+  --font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', 'Fira Mono', monospace;
   color-scheme: light dark;
 }
 
 body {
-  font-family: var(--font-body);
-  line-height: 1.6;
+  font-family: var(--font-serif);
+  font-size: 1.125rem;
+  line-height: 1.7;
 }
 
-/* Shiki dual-theme support using CSS light-dark() function */
+/* --- Monospace utility class for nav, metadata, infrastructure --- */
+.font-mono-ui {
+  font-family: var(--font-mono);
+  font-weight: 400;
+  letter-spacing: 0.03em;
+}
+
+/* --- Link behavior: underline reveals on hover --- */
+a {
+  @apply anchor;
+  text-decoration: underline;
+  text-decoration-color: oklch(62% 0.08 155 / 0.3);
+  text-underline-offset: 3px;
+  transition: text-decoration-color 0.2s ease;
+}
+
+a:hover {
+  text-decoration-color: oklch(62% 0.08 155 / 0.8);
+}
+
+@variant dark {
+  a {
+    text-decoration-color: oklch(62% 0.08 155 / 0.3);
+  }
+  a:hover {
+    text-decoration-color: oklch(62% 0.08 155 / 0.8);
+  }
+}
+
+/* Nav links: no underline by default */
+.nav-link {
+  text-decoration: none;
+  transition: color 0.3s ease;
+}
+.nav-link:hover {
+  text-decoration: none;
+  color: oklch(40% 0.1 155);
+}
+@variant dark {
+  .nav-link:hover {
+    color: oklch(62% 0.08 155);
+  }
+}
+
+/* --- Shiki dual-theme support --- */
 .shiki,
 .shiki span {
   color: light-dark(var(--shiki-light), var(--shiki-dark));
@@ -34,7 +78,6 @@ body {
   );
 }
 
-/* Style code blocks */
 .shiki {
   padding: 1rem;
   border-radius: 0.5rem;
@@ -46,9 +89,8 @@ body {
   font-family: var(--font-mono);
 }
 
-/* Skeleton preset-typo: Semantic Typography System */
+/* --- Skeleton preset-typo: Semantic Typography System --- */
 
-/* Headings */
 .preset-typo-display-4,
 .preset-typo-display-3,
 .preset-typo-display-2,
@@ -67,7 +109,6 @@ body {
   }
 }
 
-/* Body */
 .preset-typo-body-1,
 .preset-typo-body-2,
 .preset-typo-caption,
@@ -79,7 +120,6 @@ body {
   }
 }
 
-/* Unique Properties */
 .preset-typo-display-4 {
   font-size: var(--text-7xl);
   @variant lg {
@@ -147,7 +187,7 @@ body {
   font-weight: bold;
 }
 
-/* Default Skeleton styles */
+/* Default Skeleton element styles */
 h1 {
   @apply h1;
 }
@@ -166,14 +206,8 @@ h5 {
 h6 {
   @apply h6;
 }
-a {
-  @apply anchor;
-}
 blockquote {
   @apply blockquote;
-}
-code {
-  @apply code;
 }
 kbd {
   @apply kbd;
@@ -189,4 +223,118 @@ mark {
 }
 hr {
   @apply hr;
+}
+
+/* --- Inline code: pebble in the stream --- */
+code {
+  @apply code;
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+  border-radius: 0.25rem;
+  padding: 0.15em 0.4em;
+}
+
+/* Inline code tinted with sage */
+:not(pre) > code {
+  background-color: color-mix(in oklab, oklch(58% 0.08 155) 8%, oklch(97% 0.01 140));
+}
+@variant dark {
+  :not(pre) > code {
+    background-color: color-mix(in oklab, oklch(58% 0.08 155) 8%, oklch(14% 0.015 160));
+  }
+}
+
+/* --- Blockquotes: a memory surfacing --- */
+blockquote {
+  margin-left: 1.5rem;
+  margin-right: 1.5rem;
+  padding-left: 1.25rem;
+  border-left-width: 3px;
+  border-left-color: oklch(62% 0.08 155 / 0.4);
+  font-style: italic;
+}
+
+/* --- Drop cap: a breath mark --- */
+.prose > p:first-of-type::first-letter {
+  float: left;
+  font-family: var(--font-serif);
+  font-size: 3.2em;
+  line-height: 0.8;
+  padding-right: 0.12em;
+  padding-top: 0.08em;
+  color: oklch(40% 0.1 155);
+}
+@variant dark {
+  .prose > p:first-of-type::first-letter {
+    color: oklch(62% 0.08 155);
+  }
+}
+
+/* --- The :wq signoff --- */
+.signoff {
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  color: oklch(45% 0.01 80);
+  text-align: right;
+  text-decoration: none;
+}
+.signoff::after {
+  content: '\2588';
+  animation: blink 1.2s step-end infinite;
+  opacity: 0.4;
+  margin-left: 0.15em;
+}
+@variant dark {
+  .signoff {
+    color: oklch(55% 0.015 80);
+  }
+}
+
+@keyframes blink {
+  0%,
+  100% {
+    opacity: 0.4;
+  }
+  50% {
+    opacity: 0;
+  }
+}
+
+/* --- Prose overrides for the editorial feel --- */
+.prose {
+  --tw-prose-body: oklch(20% 0.01 160);
+  --tw-prose-headings: oklch(15% 0.015 160);
+  --tw-prose-links: oklch(40% 0.1 155);
+  --tw-prose-bold: oklch(15% 0.015 160);
+  --tw-prose-quotes: oklch(30% 0.01 160);
+  --tw-prose-quote-borders: oklch(62% 0.08 155 / 0.4);
+  --tw-prose-code: oklch(30% 0.01 160);
+  --tw-prose-hr: oklch(87% 0.012 155);
+}
+.prose.dark\:prose-invert:where([data-mode='dark'], .dark *) {
+  --tw-prose-body: oklch(90% 0.02 80);
+  --tw-prose-headings: oklch(93% 0.015 80);
+  --tw-prose-links: oklch(62% 0.08 155);
+  --tw-prose-bold: oklch(93% 0.015 80);
+  --tw-prose-quotes: oklch(80% 0.015 80);
+  --tw-prose-quote-borders: oklch(62% 0.08 155 / 0.4);
+  --tw-prose-code: oklch(85% 0.015 80);
+  --tw-prose-hr: oklch(26% 0.012 160);
+}
+
+/* --- Subtle top glow --- */
+.top-glow::before {
+  content: '';
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 40vh;
+  background: radial-gradient(
+    ellipse 80% 50% at 50% 0%,
+    color-mix(in oklab, oklch(58% 0.08 155) 3%, transparent),
+    transparent
+  );
+  pointer-events: none;
+  z-index: 0;
 }

--- a/src/espresso.css
+++ b/src/espresso.css
@@ -1,51 +1,61 @@
 [data-theme='espresso'] {
   --text-scaling: 1.067;
-  --base-font-color: var(--color-surface-700);
-  --base-font-color-dark: var(--color-surface-50);
-  --base-font-family: system-ui, sans-serif;
-  --base-font-size: inherit;
-  --base-line-height: inherit;
+
+  /* Typography — serif voice throughout */
+  --base-font-color: oklch(20% 0.01 160);
+  --base-font-color-dark: oklch(90% 0.02 80);
+  --base-font-family: 'Literata Variable', 'Literata', Georgia, 'Times New Roman', serif;
+  --base-font-size: 1.125rem;
+  --base-line-height: 1.7;
   --base-font-weight: normal;
   --base-font-style: normal;
   --base-letter-spacing: 0em;
-  --heading-font-color: var(--color-tertiary-500);
-  --heading-font-color-dark: var(--color-secondary-200);
-  --heading-font-family:
-    Seravek, 'Gill Sans Nova', Ubuntu, Calibri, 'DejaVu Sans', source-sans-pro, sans-serif;
-  --heading-font-weight: bolder;
+
+  /* Headings — same serif, heavier */
+  --heading-font-color: oklch(15% 0.015 160);
+  --heading-font-color-dark: oklch(93% 0.015 80);
+  --heading-font-family: 'Literata Variable', 'Literata', Georgia, 'Times New Roman', serif;
+  --heading-font-weight: 700;
   --heading-font-style: normal;
-  --heading-letter-spacing: inherit;
-  --anchor-font-color: var(--color-primary-600);
-  --anchor-font-color-dark: var(--color-tertiary-400);
+  --heading-letter-spacing: -0.01em;
+
+  /* Links — sage, understated */
+  --anchor-font-color: oklch(40% 0.1 155);
+  --anchor-font-color-dark: oklch(62% 0.08 155);
   --anchor-font-family: inherit;
   --anchor-font-size: inherit;
   --anchor-line-height: inherit;
   --anchor-font-weight: normal;
   --anchor-font-style: normal;
   --anchor-letter-spacing: inherit;
-  --anchor-text-decoration: none;
+  --anchor-text-decoration: underline;
   --anchor-text-decoration-hover: underline;
-  --anchor-text-decoration-active: none;
-  --anchor-text-decoration-focus: none;
+  --anchor-text-decoration-active: underline;
+  --anchor-text-decoration-focus: underline;
+
   --spacing: 0.25rem;
-  --radius-base: 0.375rem;
-  --radius-container: 0.75rem;
+  --radius-base: 0.25rem;
+  --radius-container: 0.5rem;
   --default-border-width: 1px;
   --default-divide-width: 1px;
   --default-ring-width: 1px;
-  --body-background-color: oklch(1 0 0 / 1);
-  --body-background-color-dark: var(--color-surface-950);
-  --color-primary-50: oklch(99.55% 0.01 196.76deg);
-  --color-primary-100: oklch(92.85% 0.03 269.34deg);
-  --color-primary-200: oklch(86.1% 0.07 273.73deg);
-  --color-primary-300: oklch(79.42% 0.1 274.67deg);
-  --color-primary-400: oklch(72.78% 0.14 274.26deg);
-  --color-primary-500: oklch(66.37% 0.18 273.14deg);
-  --color-primary-600: oklch(59.31% 0.17 271.57deg);
-  --color-primary-700: oklch(52.32% 0.17 269.51deg);
-  --color-primary-800: oklch(45.1% 0.17 267.87deg);
-  --color-primary-900: oklch(38.01% 0.17 265.59deg);
-  --color-primary-950: oklch(30.85% 0.16 263.43deg);
+
+  /* Backgrounds */
+  --body-background-color: oklch(97% 0.01 140);
+  --body-background-color-dark: oklch(14% 0.015 160);
+
+  /* Primary — sage greens */
+  --color-primary-50: oklch(96% 0.02 155);
+  --color-primary-100: oklch(90% 0.04 155);
+  --color-primary-200: oklch(82% 0.06 155);
+  --color-primary-300: oklch(74% 0.07 155);
+  --color-primary-400: oklch(66% 0.08 155);
+  --color-primary-500: oklch(58% 0.08 155);
+  --color-primary-600: oklch(50% 0.07 155);
+  --color-primary-700: oklch(42% 0.06 155);
+  --color-primary-800: oklch(34% 0.05 155);
+  --color-primary-900: oklch(26% 0.04 155);
+  --color-primary-950: oklch(18% 0.03 155);
   --color-primary-contrast-dark: var(--color-primary-950);
   --color-primary-contrast-light: var(--color-primary-50);
   --color-primary-contrast-50: var(--color-primary-contrast-dark);
@@ -53,23 +63,25 @@
   --color-primary-contrast-200: var(--color-primary-contrast-dark);
   --color-primary-contrast-300: var(--color-primary-contrast-dark);
   --color-primary-contrast-400: var(--color-primary-contrast-dark);
-  --color-primary-contrast-500: var(--color-primary-contrast-dark);
+  --color-primary-contrast-500: var(--color-primary-contrast-light);
   --color-primary-contrast-600: var(--color-primary-contrast-light);
   --color-primary-contrast-700: var(--color-primary-contrast-light);
   --color-primary-contrast-800: var(--color-primary-contrast-light);
   --color-primary-contrast-900: var(--color-primary-contrast-light);
   --color-primary-contrast-950: var(--color-primary-contrast-light);
-  --color-secondary-50: oklch(89.63% 0.1 326.37deg);
-  --color-secondary-100: oklch(83.26% 0.11 329.61deg);
-  --color-secondary-200: oklch(76.77% 0.13 331.94deg);
-  --color-secondary-300: oklch(70.62% 0.14 334.04deg);
-  --color-secondary-400: oklch(64.23% 0.15 336.05deg);
-  --color-secondary-500: oklch(58.13% 0.17 338.45deg);
-  --color-secondary-600: oklch(51.82% 0.16 338.83deg);
-  --color-secondary-700: oklch(45.2% 0.14 338.88deg);
-  --color-secondary-800: oklch(38.54% 0.13 339.5deg);
-  --color-secondary-900: oklch(31.53% 0.12 339.85deg);
-  --color-secondary-950: oklch(24.24% 0.1 341.1deg);
+
+  /* Secondary — warm grays with amber lean */
+  --color-secondary-50: oklch(96% 0.01 80);
+  --color-secondary-100: oklch(90% 0.012 80);
+  --color-secondary-200: oklch(82% 0.015 80);
+  --color-secondary-300: oklch(72% 0.015 80);
+  --color-secondary-400: oklch(62% 0.015 80);
+  --color-secondary-500: oklch(55% 0.015 80);
+  --color-secondary-600: oklch(48% 0.012 80);
+  --color-secondary-700: oklch(40% 0.01 80);
+  --color-secondary-800: oklch(32% 0.01 80);
+  --color-secondary-900: oklch(24% 0.008 80);
+  --color-secondary-950: oklch(16% 0.006 80);
   --color-secondary-contrast-dark: var(--color-secondary-950);
   --color-secondary-contrast-light: var(--color-secondary-50);
   --color-secondary-contrast-50: var(--color-secondary-contrast-dark);
@@ -83,17 +95,19 @@
   --color-secondary-contrast-800: var(--color-secondary-contrast-light);
   --color-secondary-contrast-900: var(--color-secondary-contrast-light);
   --color-secondary-contrast-950: var(--color-secondary-contrast-light);
-  --color-tertiary-50: oklch(95.13% 0.07 195.96deg);
-  --color-tertiary-100: oklch(89% 0.08 199.52deg);
-  --color-tertiary-200: oklch(82.93% 0.09 202.55deg);
-  --color-tertiary-300: oklch(76.65% 0.1 206.97deg);
-  --color-tertiary-400: oklch(70.67% 0.1 209.72deg);
-  --color-tertiary-500: oklch(64.77% 0.11 212.88deg);
-  --color-tertiary-600: oklch(58.17% 0.1 214.43deg);
-  --color-tertiary-700: oklch(51.36% 0.09 216.39deg);
-  --color-tertiary-800: oklch(44.12% 0.08 221.58deg);
-  --color-tertiary-900: oklch(36.77% 0.07 225.7deg);
-  --color-tertiary-950: oklch(29% 0.06 231.13deg);
+
+  /* Tertiary — deeper sage for variety */
+  --color-tertiary-50: oklch(95% 0.03 155);
+  --color-tertiary-100: oklch(88% 0.05 155);
+  --color-tertiary-200: oklch(80% 0.07 155);
+  --color-tertiary-300: oklch(72% 0.08 155);
+  --color-tertiary-400: oklch(62% 0.08 155);
+  --color-tertiary-500: oklch(52% 0.07 155);
+  --color-tertiary-600: oklch(44% 0.06 155);
+  --color-tertiary-700: oklch(36% 0.05 155);
+  --color-tertiary-800: oklch(28% 0.04 155);
+  --color-tertiary-900: oklch(20% 0.03 155);
+  --color-tertiary-950: oklch(14% 0.02 155);
   --color-tertiary-contrast-dark: var(--color-tertiary-950);
   --color-tertiary-contrast-light: var(--color-tertiary-50);
   --color-tertiary-contrast-50: var(--color-tertiary-contrast-dark);
@@ -101,23 +115,25 @@
   --color-tertiary-contrast-200: var(--color-tertiary-contrast-dark);
   --color-tertiary-contrast-300: var(--color-tertiary-contrast-dark);
   --color-tertiary-contrast-400: var(--color-tertiary-contrast-dark);
-  --color-tertiary-contrast-500: var(--color-tertiary-contrast-dark);
+  --color-tertiary-contrast-500: var(--color-tertiary-contrast-light);
   --color-tertiary-contrast-600: var(--color-tertiary-contrast-light);
   --color-tertiary-contrast-700: var(--color-tertiary-contrast-light);
   --color-tertiary-contrast-800: var(--color-tertiary-contrast-light);
   --color-tertiary-contrast-900: var(--color-tertiary-contrast-light);
   --color-tertiary-contrast-950: var(--color-tertiary-contrast-light);
-  --color-success-50: oklch(93.73% 0.13 135.56deg);
-  --color-success-100: oklch(87.53% 0.14 136.83deg);
-  --color-success-200: oklch(81.28% 0.15 137.92deg);
-  --color-success-300: oklch(75.02% 0.16 138.87deg);
-  --color-success-400: oklch(68.75% 0.17 139.69deg);
-  --color-success-500: oklch(62.5% 0.18 140.44deg);
-  --color-success-600: oklch(55.7% 0.16 140.71deg);
-  --color-success-700: oklch(48.98% 0.14 141.2deg);
-  --color-success-800: oklch(41.76% 0.12 141.45deg);
-  --color-success-900: oklch(34.52% 0.11 142.13deg);
-  --color-success-950: oklch(26.44% 0.09 142.5deg);
+
+  /* Success */
+  --color-success-50: oklch(93% 0.13 135);
+  --color-success-100: oklch(87% 0.14 136);
+  --color-success-200: oklch(81% 0.15 137);
+  --color-success-300: oklch(75% 0.16 138);
+  --color-success-400: oklch(68% 0.17 139);
+  --color-success-500: oklch(62% 0.18 140);
+  --color-success-600: oklch(55% 0.16 140);
+  --color-success-700: oklch(48% 0.14 141);
+  --color-success-800: oklch(41% 0.12 141);
+  --color-success-900: oklch(34% 0.11 142);
+  --color-success-950: oklch(26% 0.09 142);
   --color-success-contrast-dark: var(--color-success-950);
   --color-success-contrast-light: var(--color-success-50);
   --color-success-contrast-50: var(--color-success-contrast-dark);
@@ -131,17 +147,19 @@
   --color-success-contrast-800: var(--color-success-contrast-light);
   --color-success-contrast-900: var(--color-success-contrast-light);
   --color-success-contrast-950: var(--color-success-contrast-light);
-  --color-warning-50: oklch(97.87% 0.12 108.45deg);
-  --color-warning-100: oklch(92.37% 0.12 100.01deg);
-  --color-warning-200: oklch(87.03% 0.13 92.6deg);
-  --color-warning-300: oklch(81.65% 0.14 84.21deg);
-  --color-warning-400: oklch(76.48% 0.14 76.7deg);
-  --color-warning-500: oklch(71.4% 0.15 67.77deg);
-  --color-warning-600: oklch(64.17% 0.14 64.59deg);
-  --color-warning-700: oklch(56.76% 0.13 60.67deg);
-  --color-warning-800: oklch(49.33% 0.11 56.4deg);
-  --color-warning-900: oklch(41.49% 0.11 50.43deg);
-  --color-warning-950: oklch(33.42% 0.1 44.18deg);
+
+  /* Warning */
+  --color-warning-50: oklch(97% 0.12 108);
+  --color-warning-100: oklch(92% 0.12 100);
+  --color-warning-200: oklch(87% 0.13 92);
+  --color-warning-300: oklch(81% 0.14 84);
+  --color-warning-400: oklch(76% 0.14 76);
+  --color-warning-500: oklch(71% 0.15 67);
+  --color-warning-600: oklch(64% 0.14 64);
+  --color-warning-700: oklch(56% 0.13 60);
+  --color-warning-800: oklch(49% 0.11 56);
+  --color-warning-900: oklch(41% 0.11 50);
+  --color-warning-950: oklch(33% 0.1 44);
   --color-warning-contrast-dark: var(--color-warning-950);
   --color-warning-contrast-light: var(--color-warning-50);
   --color-warning-contrast-50: var(--color-warning-contrast-dark);
@@ -155,17 +173,19 @@
   --color-warning-contrast-800: var(--color-warning-contrast-light);
   --color-warning-contrast-900: var(--color-warning-contrast-light);
   --color-warning-contrast-950: var(--color-warning-contrast-light);
-  --color-error-50: oklch(81.18% 0.11 17.52deg);
-  --color-error-100: oklch(74.73% 0.14 14.61deg);
-  --color-error-200: oklch(68.66% 0.16 13.61deg);
-  --color-error-300: oklch(63.17% 0.19 14.52deg);
-  --color-error-400: oklch(58.55% 0.21 16.42deg);
-  --color-error-500: oklch(55.05% 0.22 19.81deg);
-  --color-error-600: oklch(49.65% 0.19 20.67deg);
-  --color-error-700: oklch(44.29% 0.17 22.21deg);
-  --color-error-800: oklch(38.56% 0.15 23.6deg);
-  --color-error-900: oklch(32.78% 0.13 25.71deg);
-  --color-error-950: oklch(26.39% 0.11 29.23deg);
+
+  /* Error */
+  --color-error-50: oklch(81% 0.11 17);
+  --color-error-100: oklch(74% 0.14 14);
+  --color-error-200: oklch(68% 0.16 13);
+  --color-error-300: oklch(63% 0.19 14);
+  --color-error-400: oklch(58% 0.21 16);
+  --color-error-500: oklch(55% 0.22 19);
+  --color-error-600: oklch(49% 0.19 20);
+  --color-error-700: oklch(44% 0.17 22);
+  --color-error-800: oklch(38% 0.15 23);
+  --color-error-900: oklch(32% 0.13 25);
+  --color-error-950: oklch(26% 0.11 29);
   --color-error-contrast-dark: var(--color-error-950);
   --color-error-contrast-light: var(--color-error-50);
   --color-error-contrast-50: var(--color-error-contrast-dark);
@@ -179,17 +199,19 @@
   --color-error-contrast-800: var(--color-error-contrast-light);
   --color-error-contrast-900: var(--color-error-contrast-light);
   --color-error-contrast-950: var(--color-error-contrast-light);
-  --color-surface-50: oklch(90.64% 0.01 267.4deg);
-  --color-surface-100: oklch(85.79% 0.01 271.31deg);
-  --color-surface-200: oklch(80.91% 0.02 274.81deg);
-  --color-surface-300: oklch(75.63% 0.02 276.88deg);
-  --color-surface-400: oklch(70.59% 0.03 278.21deg);
-  --color-surface-500: oklch(65.43% 0.03 278.8deg);
-  --color-surface-600: oklch(56.96% 0.03 278.01deg);
-  --color-surface-700: oklch(48.24% 0.03 279.78deg);
-  --color-surface-800: oklch(38.74% 0.02 282.02deg);
-  --color-surface-900: oklch(29.02% 0.02 284.98deg);
-  --color-surface-950: oklch(18.28% 0.02 284.22deg);
+
+  /* Surface — green-tinted neutrals */
+  --color-surface-50: oklch(97% 0.008 150);
+  --color-surface-100: oklch(93% 0.01 150);
+  --color-surface-200: oklch(87% 0.012 155);
+  --color-surface-300: oklch(78% 0.012 155);
+  --color-surface-400: oklch(68% 0.012 158);
+  --color-surface-500: oklch(58% 0.012 158);
+  --color-surface-600: oklch(48% 0.01 160);
+  --color-surface-700: oklch(38% 0.01 160);
+  --color-surface-800: oklch(26% 0.012 160);
+  --color-surface-900: oklch(19% 0.015 160);
+  --color-surface-950: oklch(14% 0.015 160);
   --color-surface-contrast-dark: var(--color-surface-950);
   --color-surface-contrast-light: var(--color-surface-50);
   --color-surface-contrast-50: var(--color-surface-contrast-dark);

--- a/src/lib/components/Breadcrumbs.svelte
+++ b/src/lib/components/Breadcrumbs.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { ChevronRight } from 'lucide-svelte';
   import { resolve } from '$app/paths';
 
   interface Crumb {
@@ -11,14 +10,14 @@
 </script>
 
 <nav aria-label="Breadcrumb" class="mb-8">
-  <ol class="flex items-center gap-2 text-sm">
+  <ol class="font-mono-ui flex items-center gap-2 text-sm">
     {#each crumbs as crumb, index (index)}
       <li class="flex items-center gap-2">
         {#if index > 0}
-          <ChevronRight class="h-4 w-4 text-surface-600-400" />
+          <span class="opacity-40 select-none">&middot;</span>
         {/if}
         {#if crumb.href}
-          <a href={resolve(crumb.href)} class="anchor text-primary-500">{crumb.label}</a>
+          <a href={resolve(crumb.href)} class="nav-link lowercase">{crumb.label}</a>
         {:else}
           <span class="text-surface-600-400">{crumb.label}</span>
         {/if}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -70,32 +70,37 @@
     <meta name="twitter:card" content="summary" />
   {/if}
 </svelte:head>
-<div class="min-h-screen bg-surface-50-950 text-surface-950-50">
+<div class="top-glow min-h-screen bg-surface-50-950 text-surface-950-50">
   <!-- Header -->
-  <header class="border-b border-surface-200-800">
-    <div class="container mx-auto max-w-4xl px-4">
-      <div class="flex items-center justify-between py-6">
-        <h1 class="preset-typo-title">
-          <a href={resolve('/')} class="anchor text-primary-500">Martin Emde</a>
-        </h1>
-        <nav class="flex items-center gap-4">
-          <div class="space-x-2">
-            <a href={resolve('/blog')} class="preset-typo-menu anchor">Blog</a>
-            <a href={resolve('/projects')} class="preset-typo-menu anchor">Projects</a>
-            <a href={resolve('/about')} class="preset-typo-menu anchor">About</a>
-          </div>
+  <header class="relative z-10">
+    <div class="mx-auto max-w-3xl px-6">
+      <div class="flex items-center justify-between py-8">
+        <a href={resolve('/')} class="nav-link text-xl font-bold" style="color: oklch(40% 0.1 155);"
+          >Martin Emde</a
+        >
+        <nav class="font-mono-ui flex items-center gap-1 text-sm text-surface-600-400">
+          <a href={resolve('/blog')} class="nav-link px-2 py-1 lowercase">blog</a>
+          <span class="opacity-40 select-none">&middot;</span>
+          <a href={resolve('/projects')} class="nav-link px-2 py-1 lowercase">projects</a>
+          <span class="opacity-40 select-none">&middot;</span>
+          <a href={resolve('/about')} class="nav-link px-2 py-1 lowercase">about</a>
         </nav>
       </div>
     </div>
   </header>
   <!-- Main Content -->
-  <main class="container mx-auto max-w-4xl px-4 py-12">
+  <main class="relative z-10 mx-auto max-w-3xl px-6 py-12">
     {@render children()}
   </main>
   <!-- Footer -->
-  <footer class="border-t border-surface-200-800 py-8">
-    <div class="container mx-auto max-w-4xl px-4 text-center text-sm text-surface-600-400">
-      <p>© 2025 Martin Emde. All rights reserved.</p>
+  <footer class="relative z-10 py-12">
+    <div class="mx-auto max-w-3xl px-6">
+      <div class="flex items-end justify-between">
+        <p class="text-sm text-surface-600-400">
+          &copy; {new Date().getFullYear()} Martin Emde
+        </p>
+        <span class="signoff">:wq</span>
+      </div>
     </div>
   </footer>
 </div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -75,9 +75,7 @@
   <header class="relative z-10">
     <div class="mx-auto max-w-3xl px-6">
       <div class="flex items-center justify-between py-8">
-        <a href={resolve('/')} class="nav-link text-xl font-bold" style="color: oklch(40% 0.1 155);"
-          >Martin Emde</a
-        >
+        <a href={resolve('/')} class="site-name nav-link text-xl font-bold">Martin Emde</a>
         <nav class="font-mono-ui flex items-center gap-1 text-sm text-surface-600-400">
           <a href={resolve('/blog')} class="nav-link px-2 py-1 lowercase">blog</a>
           <span class="opacity-40 select-none">&middot;</span>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,28 +12,28 @@
 </svelte:head>
 
 <div>
-  <!-- Hero/About Section -->
-  <section class="mb-12">
+  <!-- About Section -->
+  <section class="mb-16">
     <p class="text-lg text-surface-700-300">
       AI Developer Tools Engineer at
-      <a href="https://gusto.com" rel="external" class="anchor">Gusto</a>. Founding member of
-      <a href="https://gem.coop" rel="external" class="anchor">gem.coop</a>. See also:
-      <a href="https://github.com/martinemde" rel="external" class="anchor">GitHub</a>.
+      <a href="https://gusto.com" rel="external">Gusto</a>. Founding member of
+      <a href="https://gem.coop" rel="external">gem.coop</a>. See also:
+      <a href="https://github.com/martinemde" rel="external">GitHub</a>.
     </p>
   </section>
 
   <!-- Latest Posts Section -->
   <section>
-    <h2 class="preset-typo-display-1 mb-8">Latest Blog Posts</h2>
-    <div class="space-y-8">
+    <h2 class="preset-typo-headline mb-10">Latest Posts</h2>
+    <div class="space-y-10">
       {#each data.recentPosts as post (post.slug)}
-        <article class="border-b border-surface-200-800 pb-8">
+        <article class="pb-10">
           <h3 class="preset-typo-title mb-2">
-            <a href={resolve(`/blog/${post.slug}`)} class="anchor">
+            <a href={resolve(`/blog/${post.slug}`)}>
               {post.title}
             </a>
           </h3>
-          <div class="mb-4 text-sm text-surface-600-400">
+          <div class="font-mono-ui mb-3 text-sm text-surface-600-400">
             {formatPostDate(post.date)}
           </div>
           {#if post.description}

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -10,24 +10,22 @@
 <div>
   <Breadcrumbs crumbs={[{ label: 'Home', href: '/' }, { label: 'About' }]} />
 
-  <h1 class="mb-12 text-4xl font-bold">About</h1>
+  <h1 class="mb-12 text-3xl font-bold">About</h1>
 
   <p class="text-lg text-surface-700-300">
     AI Developer Tools Engineer at
-    <a href="https://gusto.com" rel="external" class="anchor">Gusto</a>. Founding member of
-    <a href="https://gem.coop" rel="external" class="anchor">gem.coop</a>.
+    <a href="https://gusto.com" rel="external">Gusto</a>. Founding member of
+    <a href="https://gem.coop" rel="external">gem.coop</a>.
   </p>
 
   <div class="mt-8">
     <p class="text-lg text-surface-700-300">Find me on:</p>
     <ul class="mt-2 list-inside list-disc text-lg text-surface-700-300">
       <li>
-        <a href="https://github.com/martinemde" rel="external" class="anchor"
-          >@martinemde on GitHub</a
-        >
+        <a href="https://github.com/martinemde" rel="external">@martinemde on GitHub</a>
       </li>
       <li>
-        <a href="https://bsky.app/profile/martinemde.com" rel="external" class="anchor"
+        <a href="https://bsky.app/profile/martinemde.com" rel="external"
           >@martinemde.com on Bluesky</a
         >
       </li>

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -15,17 +15,17 @@
 <div>
   <Breadcrumbs crumbs={[{ label: 'Home', href: '/' }, { label: 'Blog' }]} />
 
-  <h1 class="preset-typo-display-1 mb-12">Blog Posts</h1>
+  <h1 class="preset-typo-headline mb-12">Blog Posts</h1>
 
   <div class="space-y-12">
     {#each data.posts as post (post.slug)}
-      <article class="border-b border-surface-200-800 pb-12">
+      <article class="pb-12">
         <h2 class="preset-typo-title mb-2">
-          <a href={resolve(`/blog/${post.slug}`)} class="anchor">
+          <a href={resolve(`/blog/${post.slug}`)}>
             {post.title}
           </a>
         </h2>
-        <div class="mb-4 text-sm text-surface-600-400">
+        <div class="font-mono-ui mb-3 text-sm text-surface-600-400">
           {formatPostDate(post.date)}
         </div>
         {#if post.description}

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -12,17 +12,18 @@
 <article>
   <Breadcrumbs crumbs={[{ label: 'Blog', href: '/blog' }, { label: data.metadata.title }]} />
 
-  <header class="mb-8 border-b border-surface-200-800 pb-8">
+  <header class="mb-12">
     {#if data.metadata.title}
       <h1 class="preset-typo-title mb-4">{data.metadata.title}</h1>
     {/if}
-    <div class="text-sm text-surface-600-400">
-      <div class="flex items-center justify-between gap-4">
-        {#if data.metadata.date}
-          <span>Last Updated {formatPostDate(data.metadata.date)}</span>
-        {/if}
+    <div class="font-mono-ui text-sm text-surface-600-400">
+      {#if data.metadata.date}
+        <span>{formatPostDate(data.metadata.date)}</span>
+      {/if}
+      {#if readingTime}
+        <span class="opacity-40 select-none"> &middot; </span>
         <span>{readingTime}</span>
-      </div>
+      {/if}
     </div>
   </header>
 
@@ -38,8 +39,8 @@
     <data.content />
   </div>
 
-  <footer class="mt-12 flex items-center gap-4 pt-6">
-    <span class="text-sm text-surface-600-400">Share this article:</span>
+  <footer class="mt-16 flex items-center gap-4 pt-6">
+    <span class="font-mono-ui text-sm text-surface-600-400">Share this article:</span>
     <ShareButtons
       slug={data.metadata.slug}
       title={data.metadata.title}


### PR DESCRIPTION
Replace the espresso theme with a sage-green and warm-cream palette
inspired by Sierra foothills at dusk. Switch typography to Literata
(serif) for body/headings and JetBrains Mono for nav/metadata/code.
Add drop cap on blog posts, :wq signoff with slow-blinking cursor,
middot-separated monospace nav, subtle link underline reveals, and
a faint top radial glow. Remove harsh borders in favor of breathing
space. Both light and dark modes are intentional — morning and evening
of the same room.

https://claude.ai/code/session_01TYnFoWzEZeSh6C9Ft5h5KP