### PR TITLE
Bump prettier from 3.8.3 to 3.9.6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
         "happy-dom": "^20.11.1",
         "jsdom": "^30.0.1",
         "mdsvex": "^0.12.8",
-        "prettier": "^3.8.3",
+        "prettier": "^3.9.6",
         "prettier-plugin-svelte": "^4.1.1",
         "prettier-plugin-tailwindcss": "^0.7.2",
         "shiki": "^4.3.0",
@@ -936,7 +936,7 @@
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
-    "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
+    "prettier": ["prettier@3.9.6", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
 
     "prettier-plugin-svelte": ["prettier-plugin-svelte@4.1.1", "", { "peerDependencies": { "prettier": "^3.0.0", "svelte": "^5.0.0" } }, "sha512-wXvbXMjSvb4C9ENWTHXyd+ihakKCsJ6rJhLP6/8HFNj4GkZr48jqL9PoKsl2sk7SyCZRTnJ7O2TTowUpOxP/KA=="],
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "happy-dom": "^20.11.1",
     "jsdom": "^30.0.1",
     "mdsvex": "^0.12.8",
-    "prettier": "^3.8.3",
+    "prettier": "^3.9.6",
     "prettier-plugin-svelte": "^4.1.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "shiki": "^4.3.0",

--- a/src/lib/utils/posts.ts
+++ b/src/lib/utils/posts.ts
@@ -181,12 +181,10 @@ const postIndex = buildPostIndex();
  */
 export async function getAllPosts(): Promise<Post[]> {
   // Convert the slug index to an array of posts
-  const allPosts = Array.from(postIndex.values()).map(
-    (entry): Post => ({
-      ...entry.metadata,
-      path: entry.path
-    })
-  );
+  const allPosts = Array.from(postIndex.values()).map((entry): Post => ({
+    ...entry.metadata,
+    path: entry.path
+  }));
 
   // Filter published posts and sort by date (newest first)
   return allPosts


### PR DESCRIPTION
Supersedes #227.

Bumps [prettier](https://github.com/prettier/prettier) from 3.8.3 to 3.9.6.

Dependabot's PR failed `lint`: prettier 3.9 changed how it formats an arrow function whose body is a parenthesized object literal, so `getAllPosts` in `src/lib/utils/posts.ts` needed reformatting. That formatting fix is included here.

Redone on top of current `main` rather than pushed to the dependabot branch, since that branch's `bun.lock` predates the eslint 10.8.0 bump (#228), and pushes to dependabot branches don't trigger CI.

Verified locally: `bun run lint`, `bun run check`, and `bun run test` (228 tests) all pass.