### PR TITLE
Add "Give Away Elon's Money" — a trillion-dollar spending game

### DIFF
--- a/src/lib/data/projects.ts
+++ b/src/lib/data/projects.ts
@@ -5,6 +5,7 @@
 import { resolve } from '$app/paths';
 import {
   Armchair,
+  Banknote,
   Calculator,
   Cat,
   Code,
@@ -89,6 +90,13 @@ export const projects: Project[] = [
       'Score tracker for Sushi Go! Spin Some for Dim Sum. Supports 2-6 players with automatic scoring for all dim sum cards.',
     url: resolve('/dimsum'),
     icon: UtensilsCrossed
+  },
+  {
+    name: "Give Away Elon's Money",
+    description:
+      'A trillion dollars, a thousand squares, and a list of real sourced prices for fixing things. Fund what you like and watch how little the pile moves.',
+    url: resolve('/trillion'),
+    icon: Banknote
   },
   {
     name: 'Loan Calculator',

--- a/src/lib/trillion/game.test.ts
+++ b/src/lib/trillion/game.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from 'vitest';
+import {
+  BLOCKS,
+  FORTUNE,
+  allocations,
+  blockOwners,
+  canAfford,
+  clampUnits,
+  formatExact,
+  formatMoney,
+  formatShare,
+  itemTotal,
+  maxUnits,
+  receipt,
+  remaining,
+  shortfall,
+  spentFraction,
+  totalSpent,
+  type Item,
+  type Tier
+} from './game';
+import { allItems, tiers } from './items';
+
+const oneTime: Item = {
+  id: 'one',
+  label: 'One time',
+  cost: 10_000_000_000,
+  note: '',
+  sources: []
+};
+
+const yearly: Item = {
+  id: 'yearly',
+  label: 'Yearly',
+  cost: 5_000_000_000,
+  per: 'year',
+  maxUnits: 4,
+  note: '',
+  sources: []
+};
+
+const testTiers: Tier[] = [
+  { id: 'a', title: 'A', kicker: '', lede: '', items: [oneTime] },
+  { id: 'b', title: 'B', kicker: '', lede: '', items: [yearly] }
+];
+
+describe('units', () => {
+  it('caps one-time items at a single purchase', () => {
+    expect(maxUnits(oneTime)).toBe(1);
+    expect(clampUnits(oneTime, 7)).toBe(1);
+  });
+
+  it('caps recurring items at their maxUnits', () => {
+    expect(maxUnits(yearly)).toBe(4);
+    expect(clampUnits(yearly, 9)).toBe(4);
+    expect(clampUnits(yearly, 3)).toBe(3);
+  });
+
+  it('treats missing, zero and nonsense units as unfunded', () => {
+    expect(clampUnits(yearly, 0)).toBe(0);
+    expect(clampUnits(yearly, -2)).toBe(0);
+    expect(clampUnits(yearly, NaN)).toBe(0);
+  });
+
+  it('multiplies recurring costs by years', () => {
+    expect(itemTotal(yearly, 3)).toBe(15_000_000_000);
+    expect(itemTotal(oneTime, 3)).toBe(10_000_000_000);
+  });
+});
+
+describe('spending', () => {
+  it('starts with the whole fortune unspent', () => {
+    expect(totalSpent(testTiers, {})).toBe(0);
+    expect(remaining(testTiers, {})).toBe(FORTUNE);
+  });
+
+  it('adds up funded items across tiers', () => {
+    const funded = { one: 1, yearly: 2 };
+    expect(totalSpent(testTiers, funded)).toBe(20_000_000_000);
+    expect(remaining(testTiers, funded)).toBe(FORTUNE - 20_000_000_000);
+  });
+
+  it('ignores ids that are not on the board', () => {
+    expect(totalSpent(testTiers, { ghost: 5 })).toBe(0);
+  });
+
+  it('lists allocations in page order', () => {
+    const allocs = allocations(testTiers, { one: 1, yearly: 1 });
+    expect(allocs.map((a) => a.item.id)).toEqual(['one', 'yearly']);
+    expect(allocs[1].tierId).toBe('b');
+  });
+
+  it('sorts the receipt biggest first', () => {
+    const allocs = allocations(testTiers, { one: 1, yearly: 4 });
+    expect(receipt(allocs).map((a) => a.item.id)).toEqual(['yearly', 'one']);
+  });
+});
+
+describe('affordability', () => {
+  it('knows what fits in what is left', () => {
+    expect(canAfford(100, 100)).toBe(true);
+    expect(canAfford(101, 100)).toBe(false);
+  });
+
+  it('reports how far short you are, never negative', () => {
+    expect(shortfall(1_866_000_000_000, FORTUNE)).toBe(866_000_000_000);
+    expect(shortfall(10, 100)).toBe(0);
+  });
+});
+
+describe('the block grid', () => {
+  it('has one square per billion dollars', () => {
+    expect(BLOCKS).toBe(1000);
+    expect(blockOwners([])).toHaveLength(BLOCKS);
+    expect(blockOwners([]).every((owner) => owner === null)).toBe(true);
+  });
+
+  it('colors one square per billion spent', () => {
+    const owners = blockOwners(allocations(testTiers, { one: 1 }));
+    expect(owners.filter((o) => o === 'a')).toHaveLength(10);
+    expect(owners.slice(0, 10).every((o) => o === 'a')).toBe(true);
+    expect(owners[10]).toBeNull();
+  });
+
+  it('gives sub-billion purchases no square at all', () => {
+    const tiny: Tier[] = [
+      {
+        id: 'tiny',
+        title: '',
+        kicker: '',
+        lede: '',
+        items: [{ id: 'tiny', label: '', cost: 450_300_000, note: '', sources: [] }]
+      }
+    ];
+    expect(blockOwners(allocations(tiny, { tiny: 1 })).every((o) => o === null)).toBe(true);
+  });
+
+  it('never paints past the end of the grid when you overspend', () => {
+    const owners = blockOwners([{ item: oneTime, tierId: 'a', units: 1, amount: FORTUNE * 3 }]);
+    expect(owners).toHaveLength(BLOCKS);
+    expect(owners.every((o) => o === 'a')).toBe(true);
+  });
+});
+
+describe('formatting', () => {
+  it('scales money to T, B and M', () => {
+    expect(formatMoney(1_866_000_000_000)).toBe('$1.87T');
+    expect(formatMoney(228_000_000_000)).toBe('$228B');
+    expect(formatMoney(6_900_000_000)).toBe('$6.9B');
+    expect(formatMoney(450_300_000)).toBe('$450M');
+    expect(formatMoney(1_500_000)).toBe('$1.5M');
+    expect(formatMoney(0)).toBe('$0');
+  });
+
+  it('drops trailing zeros rather than printing $6.00B', () => {
+    expect(formatMoney(6_000_000_000)).toBe('$6B');
+    expect(formatMoney(1_000_000_000_000)).toBe('$1T');
+  });
+
+  it('writes the counter out in full', () => {
+    expect(formatExact(FORTUNE)).toBe('$1,000,000,000,000');
+    expect(formatExact(941_300_000_000)).toBe('$941,300,000,000');
+  });
+
+  it('keeps small shares legible instead of rounding them to zero', () => {
+    expect(formatShare(450_300_000)).toBe('0.05%');
+    expect(formatShare(228_000_000_000)).toBe('23%');
+    expect(formatShare(6_900_000_000)).toBe('0.69%');
+    expect(formatShare(1_000_000)).toBe('<0.01%');
+    expect(formatShare(0)).toBe('0%');
+    expect(formatShare(FORTUNE)).toBe('100%');
+  });
+
+  it('clamps the progress fraction', () => {
+    expect(spentFraction(0)).toBe(0);
+    expect(spentFraction(FORTUNE / 2)).toBe(0.5);
+    expect(spentFraction(FORTUNE * 2)).toBe(1);
+  });
+});
+
+describe('the catalog', () => {
+  it('gives every item a unique id', () => {
+    const ids = allItems.map((item) => item.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('cites a source for every price', () => {
+    for (const item of allItems) {
+      expect(item.sources.length, `${item.id} has no source`).toBeGreaterThan(0);
+      for (const source of item.sources) {
+        expect(source.url, `${item.id} source is not a URL`).toMatch(/^https:\/\//);
+      }
+    }
+  });
+
+  it('explains every price', () => {
+    for (const item of allItems) {
+      expect(item.note.length, `${item.id} has no note`).toBeGreaterThan(20);
+    }
+  });
+
+  it('opens cheap and ends beyond reach', () => {
+    const first = tiers[0].items.map((i) => i.cost);
+    expect(Math.max(...first)).toBeLessThan(FORTUNE * 0.01);
+
+    const wall = tiers[tiers.length - 1].items;
+    expect(wall.some((item) => item.cost > FORTUNE)).toBe(true);
+  });
+
+  it('can be fully funded by nobody — the catalog outruns the fortune', () => {
+    const everything = Object.fromEntries(allItems.map((item) => [item.id, maxUnits(item)]));
+    expect(totalSpent(tiers, everything)).toBeGreaterThan(FORTUNE);
+  });
+});

--- a/src/lib/trillion/game.test.ts
+++ b/src/lib/trillion/game.test.ts
@@ -3,7 +3,9 @@ import {
   BLOCKS,
   FORTUNE,
   allocations,
+  bankrollAt,
   blockOwners,
+  blockValue,
   canAfford,
   clampUnits,
   formatExact,
@@ -11,15 +13,20 @@ import {
   formatShare,
   itemTotal,
   maxUnits,
+  needsUpgrade,
+  nextBankroll,
+  overdraft,
+  rungFor,
   receipt,
   remaining,
   shortfall,
   spentFraction,
   totalSpent,
+  type Bankroll,
   type Item,
   type Tier
 } from './game';
-import { allItems, tiers } from './items';
+import { allItems, bankrolls, tiers } from './items';
 
 const oneTime: Item = {
   id: 'one',
@@ -102,9 +109,107 @@ describe('affordability', () => {
     expect(canAfford(101, 100)).toBe(false);
   });
 
+  it('lets the last bankroll buy anything at all', () => {
+    expect(canAfford(1e15, 100, true)).toBe(true);
+  });
+
   it('reports how far short you are, never negative', () => {
     expect(shortfall(1_866_000_000_000, FORTUNE)).toBe(866_000_000_000);
     expect(shortfall(10, 100)).toBe(0);
+  });
+});
+
+describe('bankrolls', () => {
+  const ladder: Bankroll[] = [
+    {
+      id: 'a',
+      label: 'A',
+      short: 'A',
+      people: '1',
+      exhausted: 'x',
+      amount: 100,
+      note: '',
+      sources: []
+    },
+    {
+      id: 'b',
+      label: 'B',
+      short: 'B',
+      people: '2',
+      exhausted: 'x',
+      amount: 500,
+      note: '',
+      sources: []
+    },
+    {
+      id: 'red',
+      label: 'red',
+      short: 'red',
+      people: 'nobody',
+      exhausted: 'x',
+      amount: 500,
+      unlimited: true,
+      note: '',
+      sources: []
+    }
+  ];
+
+  it('walks up the ladder and stops at the top', () => {
+    expect(bankrollAt(ladder, 0).id).toBe('a');
+    expect(nextBankroll(ladder, 0)?.id).toBe('b');
+    expect(nextBankroll(ladder, 2)).toBeUndefined();
+  });
+
+  it('clamps a saved level that no longer exists', () => {
+    expect(bankrollAt(ladder, 99).id).toBe('red');
+    expect(bankrollAt(ladder, -3).id).toBe('a');
+    expect(bankrollAt(ladder, NaN).id).toBe('a');
+  });
+
+  it('asks for an upgrade only when one exists and the money does not', () => {
+    expect(needsUpgrade(50, 100, ladder, 0)).toBe(false); // affordable
+    expect(needsUpgrade(150, 100, ladder, 0)).toBe(true); // too big, rung above
+    expect(needsUpgrade(1e9, 100, ladder, 2)).toBe(false); // last rung: just go red
+  });
+
+  it('offers the lowest rung that actually covers the purchase', () => {
+    expect(rungFor(ladder, 0, 90)).toBe(1); // fits in B
+    expect(rungFor(ladder, 0, 400)).toBe(1); // still fits in B
+    expect(rungFor(ladder, 0, 900)).toBe(2); // nothing covers it: the red
+    expect(rungFor(ladder, 1, 900)).toBe(2);
+  });
+
+  it('never lands you in the red by accepting a survivable offer', () => {
+    // Accepting an offer for a purchase a real rung can hold must leave >= 0.
+    for (const needed of [50, 120, 300, 500]) {
+      const rung = ladder[rungFor(ladder, 0, needed)];
+      expect(rung.unlimited || rung.amount >= needed).toBe(true);
+    }
+  });
+
+  it('reports the overdraft only once you are past the pot', () => {
+    expect(overdraft(400, 500)).toBe(0);
+    expect(overdraft(500, 500)).toBe(0);
+    expect(overdraft(700, 500)).toBe(200);
+  });
+
+  it('ships a ladder that climbs, ending somewhere nobody can be billed', () => {
+    expect(bankrolls[0].amount).toBe(FORTUNE);
+    const amounts = bankrolls.map((b) => b.amount);
+    for (let i = 1; i < amounts.length; i++)
+      expect(amounts[i]).toBeGreaterThanOrEqual(amounts[i - 1]);
+    expect(bankrolls.at(-1)?.unlimited).toBe(true);
+    for (const b of bankrolls) {
+      expect(b.sources.length, `${b.id} has no source`).toBeGreaterThan(0);
+      expect(b.note.length, `${b.id} has no note`).toBeGreaterThan(20);
+      expect(b.exhausted.length, `${b.id} has no out-of-money line`).toBeGreaterThan(10);
+    }
+  });
+
+  it('cannot buy the whole catalog even with every billionaire on Earth', () => {
+    const everything = Object.fromEntries(allItems.map((item) => [item.id, maxUnits(item)]));
+    const richest = bankrolls.filter((b) => !b.unlimited).at(-1)!;
+    expect(totalSpent(tiers, everything)).toBeGreaterThan(richest.amount);
   });
 });
 
@@ -113,6 +218,15 @@ describe('the block grid', () => {
     expect(BLOCKS).toBe(1000);
     expect(blockOwners([])).toHaveLength(BLOCKS);
     expect(blockOwners([]).every((owner) => owner === null)).toBe(true);
+  });
+
+  it('rescales the squares to the open bankroll', () => {
+    expect(blockValue(FORTUNE)).toBe(1_000_000_000);
+    expect(blockValue(20_100_000_000_000)).toBe(20_100_000_000);
+    // The same purchase fills fewer squares once a bigger bankroll is open.
+    const allocs = allocations(testTiers, { one: 1 });
+    expect(blockOwners(allocs, FORTUNE).filter(Boolean)).toHaveLength(10);
+    expect(blockOwners(allocs, FORTUNE * 10).filter(Boolean)).toHaveLength(1);
   });
 
   it('colors one square per billion spent', () => {
@@ -160,6 +274,11 @@ describe('formatting', () => {
   it('writes the counter out in full', () => {
     expect(formatExact(FORTUNE)).toBe('$1,000,000,000,000');
     expect(formatExact(941_300_000_000)).toBe('$941,300,000,000');
+  });
+
+  it('takes shares against whichever bankroll is open', () => {
+    expect(formatShare(FORTUNE, FORTUNE)).toBe('100%');
+    expect(formatShare(FORTUNE, 20_100_000_000_000)).toBe('5.0%');
   });
 
   it('keeps small shares legible instead of rounding them to zero', () => {

--- a/src/lib/trillion/game.ts
+++ b/src/lib/trillion/game.ts
@@ -1,0 +1,160 @@
+/**
+ * The money math behind /trillion.
+ *
+ * Everything here is pure so the page can stay a thin layer of state on top of
+ * it, and so the formatting rules (which do most of the emotional work on that
+ * page) can be pinned down in tests.
+ */
+
+/** The pile you start with. One trillion dollars, exactly. */
+export const FORTUNE = 1_000_000_000_000;
+
+/** The hero grid is 1,000 squares, so each square is a billion dollars. */
+export const BLOCKS = 1000;
+export const BLOCK_VALUE = FORTUNE / BLOCKS;
+
+export interface Source {
+  label: string;
+  url: string;
+}
+
+export interface Item {
+  id: string;
+  label: string;
+  /** One-time price, or the price of a single year when `per` is 'year'. */
+  cost: number;
+  per?: 'year';
+  /** Ceiling on the stepper for recurring items. Ignored for one-time items. */
+  maxUnits?: number;
+  /** Where the number comes from, in one sentence. */
+  note: string;
+  sources: Source[];
+}
+
+export interface Tier {
+  id: string;
+  title: string;
+  kicker: string;
+  lede: string;
+  items: Item[];
+}
+
+/** id -> units funded. Missing or 0 means unfunded; one-time items max out at 1. */
+export type Funded = Record<string, number>;
+
+export interface Allocation {
+  item: Item;
+  tierId: string;
+  units: number;
+  amount: number;
+}
+
+/** How many times you can buy a thing. One-time items are one-and-done. */
+export function maxUnits(item: Item): number {
+  return item.per ? (item.maxUnits ?? 10) : 1;
+}
+
+export function itemTotal(item: Item, units: number): number {
+  return item.cost * clampUnits(item, units);
+}
+
+export function clampUnits(item: Item, units: number): number {
+  if (!Number.isFinite(units) || units <= 0) return 0;
+  return Math.min(Math.floor(units), maxUnits(item));
+}
+
+/**
+ * Walks the tiers in page order so the ledger — and the colors in the grid —
+ * read top to bottom the way the page does.
+ */
+export function allocations(tiers: Tier[], funded: Funded): Allocation[] {
+  const out: Allocation[] = [];
+  for (const tier of tiers) {
+    for (const item of tier.items) {
+      const units = clampUnits(item, funded[item.id] ?? 0);
+      if (units > 0) {
+        out.push({ item, tierId: tier.id, units, amount: item.cost * units });
+      }
+    }
+  }
+  return out;
+}
+
+export function totalSpent(tiers: Tier[], funded: Funded): number {
+  return allocations(tiers, funded).reduce((sum, a) => sum + a.amount, 0);
+}
+
+export function remaining(tiers: Tier[], funded: Funded): number {
+  return FORTUNE - totalSpent(tiers, funded);
+}
+
+/**
+ * Paints the 1,000-square grid. Squares are handed out in ledger order, which
+ * means anything under a billion dollars can fail to color a single square —
+ * that is the point of the grid, not a rounding bug.
+ */
+export function blockOwners(allocs: Allocation[]): (string | null)[] {
+  const owners: (string | null)[] = new Array(BLOCKS).fill(null);
+  let spent = 0;
+  for (const alloc of allocs) {
+    const start = Math.floor(spent / BLOCK_VALUE);
+    spent += alloc.amount;
+    const end = Math.min(Math.floor(spent / BLOCK_VALUE), BLOCKS);
+    for (let i = Math.max(start, 0); i < end; i++) owners[i] = alloc.tierId;
+  }
+  return owners;
+}
+
+/** Rounds to a sensible number of digits for its size: 228, 6.9, 0.45. */
+function trim(value: number): string {
+  const digits = value >= 100 ? 0 : value >= 10 ? 1 : 2;
+  return Number(value.toFixed(digits)).toString();
+}
+
+/** Headline money: $450M, $6.9B, $1.87T. */
+export function formatMoney(amount: number): string {
+  const sign = amount < 0 ? '-' : '';
+  const abs = Math.abs(amount);
+  if (abs >= 1e12) return `${sign}$${trim(abs / 1e12)}T`;
+  if (abs >= 1e9) return `${sign}$${trim(abs / 1e9)}B`;
+  if (abs >= 1e6) return `${sign}$${trim(abs / 1e6)}M`;
+  return `${sign}$${Math.round(abs).toLocaleString('en-US')}`;
+}
+
+/** Every digit, for the counter at the top: $941,300,000,000. */
+export function formatExact(amount: number): string {
+  const sign = amount < 0 ? '-' : '';
+  return `${sign}$${Math.round(Math.abs(amount)).toLocaleString('en-US')}`;
+}
+
+/**
+ * Share of the fortune. Keeps two decimals under 1% because "0.04%" is the
+ * joke — collapsing it to "0%" would throw the punchline away.
+ */
+export function formatShare(amount: number): string {
+  const pct = (amount / FORTUNE) * 100;
+  if (pct <= 0) return '0%';
+  if (pct < 0.01) return '<0.01%';
+  if (pct < 1) return `${pct.toFixed(2)}%`;
+  if (pct < 10) return `${pct.toFixed(1)}%`;
+  return `${Math.round(pct)}%`;
+}
+
+/** 0-1, clamped, for progress bars. */
+export function spentFraction(spent: number): number {
+  return Math.max(0, Math.min(1, spent / FORTUNE));
+}
+
+/** What a purchase costs relative to what you have left. */
+export function shortfall(cost: number, left: number): number {
+  return Math.max(0, cost - left);
+}
+
+export function canAfford(cost: number, left: number): boolean {
+  return cost <= left;
+}
+
+/** Everything you funded, cheapest last — the receipt reads better big-first. */
+export function receipt(allocs: Allocation[]): Allocation[] {
+  return [...allocs].sort((a, b) => b.amount - a.amount);
+}

--- a/src/lib/trillion/game.ts
+++ b/src/lib/trillion/game.ts
@@ -9,7 +9,11 @@
 /** The pile you start with. One trillion dollars, exactly. */
 export const FORTUNE = 1_000_000_000_000;
 
-/** The hero grid is 1,000 squares, so each square is a billion dollars. */
+/**
+ * The hero grid is always 1,000 squares. At the starting bankroll each square
+ * is a billion dollars; unlock a bigger bankroll and the squares get bigger
+ * rather than more numerous, which is its own comment on the numbers.
+ */
 export const BLOCKS = 1000;
 export const BLOCK_VALUE = FORTUNE / BLOCKS;
 
@@ -29,6 +33,34 @@ export interface Item {
   /** Where the number comes from, in one sentence. */
   note: string;
   sources: Source[];
+}
+
+/**
+ * Whose money you are spending. Amounts are totals, not additive — the ten
+ * richest people's $2.6T already contains Musk's share of it.
+ */
+export interface Bankroll {
+  id: string;
+  /** Full name for the modal: "the ten richest people on Earth". */
+  label: string;
+  /** Short name for the wallet bar: "the top 10". */
+  short: string;
+  /** How many people are being emptied out. */
+  people: string;
+  /**
+   * The modal headline when this bankroll runs dry. Written out per rung rather
+   * than assembled, because "the top 10 has" and "US billionaires's money" is
+   * what you get from gluing a possessive onto a label.
+   */
+  exhausted: string;
+  amount: number;
+  note: string;
+  sources: Source[];
+  /**
+   * The last rung. Spending past it is allowed and the balance goes negative;
+   * `amount` still sets the grid's scale so the squares stop growing.
+   */
+  unlimited?: boolean;
 }
 
 export interface Tier {
@@ -88,18 +120,24 @@ export function remaining(tiers: Tier[], funded: Funded): number {
   return FORTUNE - totalSpent(tiers, funded);
 }
 
+/** What one square is worth at a given bankroll. */
+export function blockValue(pot: number): number {
+  return pot / BLOCKS;
+}
+
 /**
  * Paints the 1,000-square grid. Squares are handed out in ledger order, which
- * means anything under a billion dollars can fail to color a single square —
+ * means anything under one square's worth can fail to color a single square —
  * that is the point of the grid, not a rounding bug.
  */
-export function blockOwners(allocs: Allocation[]): (string | null)[] {
+export function blockOwners(allocs: Allocation[], pot: number = FORTUNE): (string | null)[] {
   const owners: (string | null)[] = new Array(BLOCKS).fill(null);
+  const per = blockValue(pot);
   let spent = 0;
   for (const alloc of allocs) {
-    const start = Math.floor(spent / BLOCK_VALUE);
+    const start = Math.floor(spent / per);
     spent += alloc.amount;
-    const end = Math.min(Math.floor(spent / BLOCK_VALUE), BLOCKS);
+    const end = Math.min(Math.floor(spent / per), BLOCKS);
     for (let i = Math.max(start, 0); i < end; i++) owners[i] = alloc.tierId;
   }
   return owners;
@@ -128,11 +166,11 @@ export function formatExact(amount: number): string {
 }
 
 /**
- * Share of the fortune. Keeps two decimals under 1% because "0.04%" is the
- * joke — collapsing it to "0%" would throw the punchline away.
+ * Share of whatever bankroll is open. Keeps two decimals under 1% because
+ * "0.04%" is the joke — collapsing it to "0%" would throw the punchline away.
  */
-export function formatShare(amount: number): string {
-  const pct = (amount / FORTUNE) * 100;
+export function formatShare(amount: number, total: number = FORTUNE): string {
+  const pct = (amount / total) * 100;
   if (pct <= 0) return '0%';
   if (pct < 0.01) return '<0.01%';
   if (pct < 1) return `${pct.toFixed(2)}%`;
@@ -141,8 +179,8 @@ export function formatShare(amount: number): string {
 }
 
 /** 0-1, clamped, for progress bars. */
-export function spentFraction(spent: number): number {
-  return Math.max(0, Math.min(1, spent / FORTUNE));
+export function spentFraction(spent: number, total: number = FORTUNE): number {
+  return Math.max(0, Math.min(1, spent / total));
 }
 
 /** What a purchase costs relative to what you have left. */
@@ -150,8 +188,51 @@ export function shortfall(cost: number, left: number): number {
   return Math.max(0, cost - left);
 }
 
-export function canAfford(cost: number, left: number): boolean {
-  return cost <= left;
+export function canAfford(cost: number, left: number, unlimited = false): boolean {
+  return unlimited || cost <= left;
+}
+
+/** The open bankroll, clamped so a stale saved level can't run off the end. */
+export function bankrollAt(bankrolls: Bankroll[], level: number): Bankroll {
+  return bankrolls[Math.max(0, Math.min(Math.floor(level) || 0, bankrolls.length - 1))];
+}
+
+/** The next rung up, or undefined once you are on the last one. */
+export function nextBankroll(bankrolls: Bankroll[], level: number): Bankroll | undefined {
+  return bankrolls[level + 1];
+}
+
+/**
+ * The lowest rung that actually covers `needed` (total committed after the
+ * purchase), or the last rung if nothing does. Offering merely the next rung up
+ * would let you accept an upgrade and still land in the red — buying a $5.3T
+ * item at the $1T pot has to jump straight to a bankroll that can hold it.
+ */
+export function rungFor(bankrolls: Bankroll[], level: number, needed: number): number {
+  for (let i = level + 1; i < bankrolls.length; i++) {
+    if (bankrolls[i].unlimited || bankrolls[i].amount >= needed) return i;
+  }
+  return bankrolls.length - 1;
+}
+
+/**
+ * Whether funding this needs a bigger bankroll before it can go through. On the
+ * last rung nothing is blocked — you just go into the red.
+ */
+export function needsUpgrade(
+  cost: number,
+  left: number,
+  bankrolls: Bankroll[],
+  level: number
+): boolean {
+  const current = bankrollAt(bankrolls, level);
+  if (current.unlimited) return false;
+  return cost > left && nextBankroll(bankrolls, level) !== undefined;
+}
+
+/** How far past the bankroll you have spent. Zero until you actually overdraw. */
+export function overdraft(spent: number, pot: number): number {
+  return Math.max(0, spent - pot);
 }
 
 /** Everything you funded, cheapest last — the receipt reads better big-first. */

--- a/src/lib/trillion/items.ts
+++ b/src/lib/trillion/items.ts
@@ -1,0 +1,542 @@
+/**
+ * The catalog for /trillion.
+ *
+ * Ground rules for anything added here:
+ *   1. Every price traces to a published figure, linked in `sources`.
+ *   2. `note` says where the number comes from and how it was arrived at,
+ *      including the arithmetic when a price is a headcount times a unit cost.
+ *   3. No scorekeeping between political teams. The subject is the size of the
+ *      number, not who ought to be writing the check.
+ *
+ * Prices are what a thing costs, not what it is worth, and the estimates behind
+ * the global ones are ranges in the underlying research. Where a range exists,
+ * these use a figure the cited source itself headlines.
+ */
+
+import type { Tier } from './game';
+
+export const tiers: Tier[] = [
+  {
+    id: 'toys',
+    title: 'Pocket change',
+    kicker: 'Tier one',
+    lede: 'Start with the things money is famous for buying. Watch the counter at the top while you do it.',
+    items: [
+      {
+        id: 'painting',
+        label: 'The most expensive painting ever sold',
+        cost: 450_300_000,
+        note: "Leonardo's Salvator Mundi, hammered down at Christie's in November 2017 — still the record for any artwork at auction.",
+        sources: [
+          {
+            label: 'Christie’s / record sale',
+            url: 'https://en.wikipedia.org/wiki/Salvator_Mundi_(Leonardo)'
+          }
+        ]
+      },
+      {
+        id: 'car',
+        label: 'The most expensive car ever sold',
+        cost: 142_000_000,
+        note: 'The 1955 Mercedes-Benz 300 SLR Uhlenhaut Coupé went for €135 million in a private RM Sotheby’s sale in 2022 — roughly $142 million.',
+        sources: [
+          {
+            label: 'RM Sotheby’s sale',
+            url: 'https://en.wikipedia.org/wiki/Mercedes-Benz_300_SLR'
+          }
+        ]
+      },
+      {
+        id: 'yacht',
+        label: 'The largest superyacht ever built',
+        cost: 600_000_000,
+        note: 'Azzam is 180 metres of custom steel and aluminium; the build is generally reported at around $600 million.',
+        sources: [{ label: 'Azzam', url: 'https://en.wikipedia.org/wiki/Azzam_(yacht)' }]
+      },
+      {
+        id: 'ohtani',
+        label: 'The richest contract in sports',
+        cost: 700_000_000,
+        note: 'Shohei Ohtani’s ten-year, $700 million deal with the Dodgers — the largest contract in sports history, most of it deferred into the 2030s. You are covering the whole thing today.',
+        sources: [
+          {
+            label: 'Dodgers contract',
+            url: 'https://en.wikipedia.org/wiki/Shohei_Ohtani'
+          }
+        ]
+      },
+      {
+        id: 'tesla-bonus',
+        label: 'A $50,000 bonus for every Tesla employee',
+        cost: 6_739_250_000,
+        note: 'Tesla reported 134,785 employees worldwide at the end of 2025. At $50,000 each that is $6.74 billion — three and a half times the painting, the car, the yacht and the contract put together.',
+        sources: [
+          {
+            label: 'Tesla FY2025 Form 10-K',
+            url: 'https://www.sec.gov/Archives/edgar/data/1318605/000162828026003952/tsla-20251231.htm'
+          }
+        ]
+      }
+    ]
+  },
+  {
+    id: 'cheap',
+    title: 'Rounding errors',
+    kicker: 'Tier two',
+    lede: 'Problems that sound unsolvable. Priced in decimal places of what you are holding.',
+    items: [
+      {
+        id: 'medical-debt',
+        label: 'Erase every medical debt in America',
+        cost: 2_200_000_000,
+        note: 'Around $220 billion in medical debt is owed nationally, but it trades for pennies. Undue Medical Debt spent $36 million to buy and cancel $30 billion of it. Priced here at a very conservative one cent on the dollar.',
+        sources: [
+          {
+            label: 'Undue Medical Debt',
+            url: 'https://unduemedicaldebt.org/press-release/undue-medical-debt-announces-largest-debt-acquisition-in-nonprofits-history/'
+          }
+        ]
+      },
+      {
+        id: 'cataracts',
+        label: 'Give sight back to 17 million people',
+        cost: 3_060_000_000,
+        note: 'Cataracts blind about 17 million people, and the surgery that fixes it costs about $178 in India. 17 million × $180 = $3.1 billion.',
+        sources: [
+          {
+            label: 'Global cataract blindness (Eye, 2024)',
+            url: 'https://www.nature.com/articles/s41433-024-02961-1'
+          },
+          {
+            label: 'Surgery pricing',
+            url: 'https://www.mdpi.com/2227-9032/10/12/2580'
+          }
+        ]
+      },
+      {
+        id: 'polio',
+        label: 'Finish off polio, forever',
+        cost: 6_900_000_000,
+        note: 'The Global Polio Eradication Initiative’s entire multi-year budget through 2029 — the last mile of a disease humanity has spent nearly 40 years cornering.',
+        sources: [
+          {
+            label: 'GPEI budget',
+            url: 'https://polioeradication.org/financing/financial-needs/financial-resource-requirements-frr/'
+          }
+        ]
+      },
+      {
+        id: 'homeless',
+        label: 'Housing for everyone in a US homeless shelter',
+        cost: 9_600_000_000,
+        per: 'year',
+        maxUnits: 20,
+        note: 'The National Alliance to End Homelessness prices permanent housing for every household that stayed in a shelter in a year at $9.6 billion. Government already spends about $35,578 a year per person left on the street.',
+        sources: [
+          {
+            label: 'National Alliance to End Homelessness',
+            url: 'https://endhomelessness.org/resources/research-and-analysis/how-much-would-it-cost-to-provide-housing-first-to-all-households-staying-in-homeless-shelters/'
+          }
+        ]
+      },
+      {
+        id: 'gavi',
+        label: 'Immunize 500 million children',
+        cost: 11_900_000_000,
+        note: 'Gavi’s full five-year budget through 2030. The alliance estimates it prevents 150 outbreaks and saves eight to nine million lives.',
+        sources: [
+          {
+            label: 'Gavi 2026–2030',
+            url: 'https://www.gavi.org/news/media-room/protecting-more-children-gavi-vaccine-alliance-plans-next-5-year-period'
+          }
+        ]
+      },
+      {
+        id: 'lead-pipes',
+        label: 'Rip out every lead pipe in America',
+        cost: 18_800_000_000,
+        note: 'The EPA counts about 4 million lead service lines still in the ground at an average replacement cost of $4,700 each.',
+        sources: [
+          {
+            label: 'Brookings on EPA estimates',
+            url: 'https://www.brookings.edu/articles/what-would-it-cost-to-replace-all-the-nations-lead-water-pipes/'
+          }
+        ]
+      },
+      {
+        id: 'global-fund',
+        label: 'Fully fund the fight against AIDS, TB and malaria',
+        cost: 18_000_000_000,
+        note: 'The Global Fund asked for $18 billion for 2027–2029 and got $12.64 billion. The full ask is modelled to save 23 million lives and prevent 400 million infections.',
+        sources: [
+          {
+            label: 'Global Fund investment case',
+            url: 'https://www.theglobalfund.org/en/investment-case/'
+          }
+        ]
+      }
+    ]
+  },
+  {
+    id: 'trophies',
+    title: 'Trophies',
+    kicker: 'Tier three',
+    lede: 'Now buy the fun stuff — the things people assume are the expensive ones. Compare these prices to the tier you just finished.',
+    items: [
+      {
+        id: 'twitter',
+        label: 'Buy Twitter. Again.',
+        cost: 44_000_000_000,
+        note: 'The 2022 price for the whole company. Two and a half times what it costs to fully fund the global fight against three of the deadliest infectious diseases on Earth.',
+        sources: [
+          {
+            label: 'Acquisition of Twitter',
+            url: 'https://en.wikipedia.org/wiki/Acquisition_of_Twitter_by_Elon_Musk'
+          }
+        ]
+      },
+      {
+        id: 'nhl',
+        label: 'Buy all 32 NHL teams',
+        cost: 70_400_000_000,
+        note: 'Forbes valued the average NHL club at $2.2 billion in 2025. Thirty-two clubs, every rink in the league.',
+        sources: [
+          {
+            label: 'Forbes NHL valuations 2025',
+            url: 'https://www.forbes.com/sites/justinteitelbaum/2025/12/11/the-nhls-most-valuable-teams-2025/'
+          }
+        ]
+      },
+      {
+        id: 'mlb',
+        label: 'Buy all 30 MLB teams',
+        cost: 78_000_000_000,
+        note: 'Average MLB franchise value hit a record $2.6 billion in 2025; thirty clubs at that average is $78 billion. The Yankees alone account for $8.2 billion of it.',
+        sources: [
+          {
+            label: 'Forbes MLB valuations 2025',
+            url: 'https://www.forbes.com/sites/justinteitelbaum/2025/03/26/baseballs-most-valuable-teams-2025/'
+          }
+        ]
+      },
+      {
+        id: 'nba',
+        label: 'Buy all 30 NBA teams',
+        cost: 160_000_000_000,
+        note: 'Forbes puts the 30 NBA clubs at just over $160 billion collectively, averaging $5.4 billion each.',
+        sources: [
+          {
+            label: 'Forbes NBA valuations 2025',
+            url: 'https://www.forbes.com/sites/justinteitelbaum/2025/10/23/the-most-valuable-nba-teams-2025/'
+          }
+        ]
+      },
+      {
+        id: 'nfl',
+        label: 'Buy all 32 NFL teams',
+        cost: 228_000_000_000,
+        note: 'Every franchise in the NFL is now worth at least $5 billion, averaging $7.1 billion, for an aggregate $228 billion. This is the single most expensive thing you have been offered so far.',
+        sources: [
+          {
+            label: 'Forbes NFL valuations 2025',
+            url: 'https://www.forbes.com/sites/justinteitelbaum/2025/08/28/the-nfls-most-valuable-teams-2025/'
+          }
+        ]
+      }
+    ]
+  },
+  {
+    id: 'country',
+    title: 'One country',
+    kicker: 'Tier four',
+    lede: 'Back to work. These are the line items of a single nation — the ones that show up in budget fights every year.',
+    items: [
+      {
+        id: 'school-meals',
+        label: 'Free school meals for every US student',
+        cost: 30_000_000_000,
+        per: 'year',
+        maxUnits: 20,
+        note: 'USDA already spends about $19 billion a year feeding kids who qualify. Dropping the paperwork and feeding all of them runs about $30 billion a year.',
+        sources: [
+          {
+            label: 'USDA National School Lunch Program',
+            url: 'https://www.ers.usda.gov/topics/food-nutrition-assistance/child-nutrition-programs/national-school-lunch-program'
+          },
+          {
+            label: 'NPR: the cost of universal meals',
+            url: 'https://www.npr.org/2024/08/30/nx-s1-5092432/the-indicator-from-planet-money-a-food-fight-over-free-school-lunch'
+          }
+        ]
+      },
+      {
+        id: 'teacher-raise',
+        label: 'A $10,000 raise for every public school teacher',
+        cost: 38_000_000_000,
+        per: 'year',
+        maxUnits: 20,
+        note: 'About 3.8 million public school teachers, at a national average salary of $74,200. Ten thousand dollars each, every year you fund it.',
+        sources: [
+          { label: 'NCES teacher counts', url: 'https://nces.ed.gov/fastfacts/display.asp?id=28' },
+          {
+            label: 'NEA teacher pay',
+            url: 'https://www.nea.org/resource-library/educator-pay-and-student-spending-how-does-your-state-rank'
+          }
+        ]
+      },
+      {
+        id: 'nih',
+        label: 'Run the entire NIH for a year',
+        cost: 47_000_000_000,
+        per: 'year',
+        maxUnits: 20,
+        note: 'The National Institutes of Health ran on a $47 billion program level in FY2025 — all of it, every institute, every grant, cancer to Alzheimer’s.',
+        sources: [
+          {
+            label: 'CRS: NIH funding',
+            url: 'https://www.congress.gov/crs-product/R43341'
+          }
+        ]
+      },
+      {
+        id: 'bridges',
+        label: 'Repair every deficient bridge in America',
+        cost: 467_000_000_000,
+        note: 'ARTBA counts 42,067 US bridges rated in poor condition, with an estimated $467 billion repair bill. One in three bridges needs work.',
+        sources: [{ label: 'ARTBA Bridge Report', url: 'https://artbabridgereport.org/' }]
+      },
+      {
+        id: 'interstate',
+        label: 'Build the Interstate Highway System from scratch',
+        cost: 500_000_000_000,
+        note: 'Almost 48,000 miles, finished in 1992 at $129 billion of the day’s money — north of half a trillion in today’s.',
+        sources: [
+          {
+            label: 'FHWA highway history',
+            url: 'https://www.fhwa.dot.gov/highwayhistory/data/page03.cfm'
+          }
+        ]
+      }
+    ]
+  },
+  {
+    id: 'planet',
+    title: 'One planet',
+    kicker: 'Tier five',
+    lede: 'The whole world now, priced by the year. These are the headline numbers of global development — the ones usually described as impossible to raise.',
+    items: [
+      {
+        id: 'malaria',
+        label: 'Eradicate malaria',
+        cost: 6_000_000_000,
+        per: 'year',
+        maxUnits: 30,
+        note: 'The Lancet Commission puts eradication at a little over $6 billion a year — about $2 billion a year more than the world already spends.',
+        sources: [
+          {
+            label: 'Lancet Commission on malaria eradication',
+            url: 'https://www.malariaeradicationcommission.com/our-work/financing-malaria-eradication'
+          }
+        ]
+      },
+      {
+        id: 'hunger',
+        label: 'End world hunger',
+        cost: 33_000_000_000,
+        per: 'year',
+        maxUnits: 10,
+        note: 'Ceres2030 read half a million studies to price it: $33 billion a year, which keeps 490 million people out of hunger and doubles the incomes of 545 million small farmers.',
+        sources: [
+          {
+            label: 'Ceres2030 / IISD',
+            url: 'https://www.iisd.org/articles/iisd-news/ending-world-hunger-2030-would-cost-330bn-study-finds'
+          }
+        ]
+      },
+      {
+        id: 'usaid',
+        label: 'Cover the entire USAID budget',
+        cost: 40_000_000_000,
+        per: 'year',
+        maxUnits: 25,
+        note: 'Congress appropriated roughly $39.6 billion for foreign assistance managed by USAID and the State Department in FY2024, the agency’s last full year before it was folded into State. Every year you fund here is one full year of that work.',
+        sources: [
+          {
+            label: 'CRS: USAID overview',
+            url: 'https://www.congress.gov/crs-product/IF10261'
+          }
+        ]
+      },
+      {
+        id: 'electricity',
+        label: 'Electricity for everyone who has none',
+        cost: 45_000_000_000,
+        per: 'year',
+        maxUnits: 10,
+        note: 'About 645 million people are projected to still lack electricity in 2030. The IEA prices universal access at roughly $45 billion a year — about 2% of annual energy sector investment.',
+        sources: [
+          {
+            label: 'IEA: access to electricity',
+            url: 'https://www.iea.org/reports/sdg7-data-and-projections/access-to-electricity'
+          }
+        ]
+      },
+      {
+        id: 'education',
+        label: 'Put every child on Earth in school',
+        cost: 97_000_000_000,
+        per: 'year',
+        maxUnits: 10,
+        note: 'UNESCO’s Global Education Monitoring Report puts the annual financing gap across 79 low- and lower-middle-income countries at $97 billion — 21% of what universal education there would cost.',
+        sources: [
+          {
+            label: 'UNESCO GEM Report',
+            url: 'https://www.unesco.org/en/articles/annual-financing-gap-education-almost-100-billion'
+          }
+        ]
+      },
+      {
+        id: 'water',
+        label: 'Clean water and a toilet for every human',
+        cost: 114_000_000_000,
+        per: 'year',
+        maxUnits: 10,
+        note: 'The World Bank prices universal safe water and sanitation across 140 low- and middle-income countries at about $114 billion a year in capital spending.',
+        sources: [
+          {
+            label: 'UN World Water Development Report',
+            url: 'https://www.unesco.org/reports/wwdr/2021/en/valuing-water-supply-sanitation-services'
+          }
+        ]
+      },
+      {
+        id: 'forests',
+        label: 'Stop tropical deforestation',
+        cost: 117_000_000_000,
+        per: 'year',
+        maxUnits: 10,
+        note: 'The Forest Declaration Assessment estimates $117–299 billion a year is needed to hit the 2030 forest goals. The world currently manages about $2.2 billion a year in dedicated public funding.',
+        sources: [
+          {
+            label: 'Forest Declaration Assessment',
+            url: 'https://forestdeclaration.org/assessment/'
+          }
+        ]
+      },
+      {
+        id: 'poverty',
+        label: 'End extreme poverty where it is worst',
+        cost: 170_000_000_000,
+        per: 'year',
+        maxUnits: 10,
+        note: 'Researchers estimate $170 billion a year would cut extreme poverty to 1% or less in the 23 low-income countries that hold about half the world’s poorest people.',
+        sources: [
+          {
+            label: 'UC Berkeley / UNU-WIDER',
+            url: 'https://vcresearch.berkeley.edu/news/what-would-it-cost-end-extreme-poverty-worldwide'
+          }
+        ]
+      }
+    ]
+  },
+  {
+    id: 'moonshots',
+    title: 'Moonshots',
+    kicker: 'Tier six',
+    lede: 'Fine. Buy the biggest things our species has ever attempted.',
+    items: [
+      {
+        id: 'apollo',
+        label: 'Run the Apollo program again',
+        cost: 257_000_000_000,
+        note: 'Every dollar of Apollo — eleven crewed missions, six landings, the Saturn V, the whole decade — priced at $257 billion in 2020 dollars.',
+        sources: [
+          {
+            label: 'The Planetary Society',
+            url: 'https://www.planetary.org/space-policy/cost-of-apollo'
+          }
+        ]
+      },
+      {
+        id: 'nuclear',
+        label: 'Build ten Vogtle-sized nuclear plants',
+        cost: 315_000_000_000,
+        note: 'Vogtle 3 and 4 cost about $31.5 billion for 2.2 GW — the most expensive nuclear build in American history. Ten more of them is 22 GW of always-on, carbon-free power.',
+        sources: [
+          {
+            label: 'Lazard LCOE+ 2025',
+            url: 'https://www.lazard.com/media/eijnqja3/lazards-lcoeplus-june-2025.pdf'
+          }
+        ]
+      },
+      {
+        id: 'solar',
+        label: 'Install a terawatt of solar',
+        cost: 1_000_000_000_000,
+        note: 'Utility-scale solar runs roughly $1 per watt installed, so a terawatt — about a thousand large power plants’ worth of peak capacity — costs about a trillion. Yes, the whole thing.',
+        sources: [
+          {
+            label: 'Lazard LCOE+ 2025',
+            url: 'https://www.lazard.com/media/eijnqja3/lazards-lcoeplus-june-2025.pdf'
+          }
+        ]
+      }
+    ]
+  },
+  {
+    id: 'wall',
+    title: 'The wall',
+    kicker: 'Tier seven',
+    lede: 'And here is the other edge of it. These are the numbers that do not care how rich anyone is.',
+    items: [
+      {
+        id: 'everyone',
+        label: 'Hand every person on Earth $120',
+        cost: 996_000_000_000,
+        note: 'There are about 8.3 billion of us. Split the entire fortune evenly and everyone alive gets $120 — one tank of gas, one week of groceries. That is what a trillion dollars is, spread across the species.',
+        sources: [
+          { label: 'World population', url: 'https://www.worldometers.info/world-population/' }
+        ]
+      },
+      {
+        id: 'student-debt',
+        label: 'Pay off all US student debt',
+        cost: 1_866_000_000_000,
+        note: 'Americans owed $1.866 trillion in student loans as of March 2026, per the Federal Reserve. The entire fortune covers a little more than half of it.',
+        sources: [
+          {
+            label: 'Federal Reserve G.19',
+            url: 'https://www.federalreserve.gov/releases/g19/current/'
+          }
+        ]
+      },
+      {
+        id: 'climate',
+        label: 'Fund the global energy transition for one year',
+        cost: 4_500_000_000_000,
+        note: 'The IEA estimates clean energy investment must reach $4.5 trillion a year by 2030 to stay on a 1.5°C path. The fortune buys about eleven weeks of it.',
+        sources: [
+          {
+            label: 'IEA via WEF',
+            url: 'https://www.weforum.org/stories/2023/09/iea-clean-energy-investment-global-warming/'
+          }
+        ]
+      },
+      {
+        id: 'healthcare',
+        label: 'Run the US health care system for one year',
+        cost: 5_300_000_000_000,
+        note: 'American health spending hit $5.3 trillion in 2024 — 18% of the entire economy, $15,474 per person. A trillion dollars covers about ten weeks of it.',
+        sources: [
+          {
+            label: 'CMS National Health Expenditures',
+            url: 'https://www.cms.gov/data-research/statistics-trends-and-reports/national-health-expenditure-data/historical'
+          }
+        ]
+      }
+    ]
+  }
+];
+
+/** Every item, flat, in page order. */
+export const allItems = tiers.flatMap((tier) => tier.items);

--- a/src/lib/trillion/items.ts
+++ b/src/lib/trillion/items.ts
@@ -13,7 +13,91 @@
  * these use a figure the cited source itself headlines.
  */
 
-import type { Tier } from './game';
+import type { Bankroll, Tier } from './game';
+
+/**
+ * The ladder of whose money is on the table. Each amount is a total rather than
+ * an increment — the ten richest people's $2.6 trillion already contains Musk's
+ * share — so unlocking a rung replaces the pot instead of adding to it.
+ */
+export const bankrolls: Bankroll[] = [
+  {
+    id: 'musk',
+    label: 'Elon Musk',
+    short: 'Elon',
+    people: '1 person',
+    exhausted: "That's more than even Elon has.",
+    amount: 1_000_000_000_000,
+    note: 'In June 2026 he became the first person ever to be worth a trillion dollars, on the back of the SpaceX listing. A round trillion is the starting pot.',
+    sources: [
+      {
+        label: 'Forbes, June 2026',
+        url: 'https://www.forbes.com/sites/tylerroush/2026/06/29/musk-is-a-trillionaire-again-spacex-and-tesla-boost-net-worth-by-50-billion/'
+      }
+    ]
+  },
+  {
+    id: 'top10',
+    label: 'the ten richest people on Earth',
+    short: 'the top 10',
+    people: '10 people',
+    exhausted: "That's more than the ten richest people on Earth have.",
+    amount: 2_600_000_000_000,
+    note: 'Musk, Page, Brin, Bezos, Zuckerberg, Ellison, Arnault, Huang, Buffett, Ortega. Everyone in the top ten is worth over $140 billion; together they hold $2.6 trillion.',
+    sources: [
+      {
+        label: 'Forbes, August 2026',
+        url: 'https://www.forbes.com/sites/forbeswealthteam/article/the-top-ten-richest-people-in-the-world/'
+      }
+    ]
+  },
+  {
+    id: 'usa',
+    label: 'every billionaire in America',
+    short: 'US billionaires',
+    people: '989 people',
+    exhausted: "That's more than every billionaire in America has.",
+    amount: 8_400_000_000_000,
+    note: 'The United States holds 989 billionaires worth $8.4 trillion between them — more than a third of all billionaire wealth on the planet.',
+    sources: [
+      {
+        label: 'Forbes 2026 list',
+        url: 'https://www.forbes.com/sites/chasewithorn/2026/03/10/2026-worlds-billionaires-list-facts-and-figures/'
+      }
+    ]
+  },
+  {
+    id: 'world',
+    label: 'every billionaire on Earth',
+    short: 'all billionaires',
+    people: '3,428 people',
+    exhausted: "That's more than every billionaire on Earth has.",
+    amount: 20_100_000_000_000,
+    note: 'A record 3,428 billionaires worth a combined $20.1 trillion — a group that got $4 trillion richer in a single year. This is the last real money on the board.',
+    sources: [
+      {
+        label: 'Forbes 2026 list',
+        url: 'https://www.forbes.com/sites/chasewithorn/2026/03/10/2026-worlds-billionaires-list-facts-and-figures/'
+      }
+    ]
+  },
+  {
+    id: 'red',
+    label: 'money that does not exist',
+    short: 'the red',
+    people: 'nobody',
+    exhausted: 'There is nobody left to bill.',
+    amount: 20_100_000_000_000,
+    unlimited: true,
+    note: 'There is nobody left to bill. Past this point the balance just goes negative and you are inventing the money, which is worth knowing about a list where everything is real.',
+    sources: [
+      {
+        label: 'Forbes 2026 list',
+        url: 'https://www.forbes.com/sites/chasewithorn/2026/03/10/2026-worlds-billionaires-list-facts-and-figures/'
+      }
+    ]
+  }
+];
 
 export const tiers: Tier[] = [
   {

--- a/src/routes/trillion/+page.svelte
+++ b/src/routes/trillion/+page.svelte
@@ -461,6 +461,20 @@
   }
 
   /* ---- Tiers ----------------------------------------------------------- */
+  /*
+   * --tier is a fill color: it sits at mid lightness so the grid squares and
+   * button fills read on either background. That same value fails as small
+   * text — 2:1 on a light card. --tier-ink is the same hue re-lit per theme
+   * for anything type-sized; fills keep --tier, text uses --tier-ink.
+   */
+  .tier,
+  .ledger li {
+    --tier-ink: light-dark(
+      color-mix(in oklch, var(--tier) 55%, black),
+      color-mix(in oklch, var(--tier) 92%, white)
+    );
+  }
+
   .tier {
     border-top: 1px solid var(--border);
     padding: 40px 0 8px;
@@ -470,7 +484,7 @@
     font-size: 11.5px;
     letter-spacing: 0.08em;
     text-transform: uppercase;
-    color: var(--tier);
+    color: var(--tier-ink);
   }
   .tier-head h2 {
     margin: 10px 0 12px;
@@ -508,8 +522,11 @@
     border-left-color: var(--tier);
     background: color-mix(in oklch, var(--tier) 7%, var(--surface));
   }
+  /* Out of reach reads as a dashed edge and a disabled button, not as dimmed
+     text — the note and the shortfall are content people still need to read. */
   .card.broke {
-    opacity: 0.62;
+    border-style: dashed;
+    background: none;
   }
   .card-top {
     display: flex;
@@ -531,7 +548,7 @@
     font-family: var(--font-mono);
     font-weight: 500;
     font-size: 16px;
-    color: var(--tier);
+    color: var(--tier-ink);
     white-space: nowrap;
   }
   .per {
@@ -562,25 +579,36 @@
     cursor: pointer;
   }
   .fund {
-    border: 1px solid var(--tier);
+    border: 1px solid var(--tier-ink);
     border-radius: 7px;
     background: transparent;
     padding: 8px 15px;
-    color: var(--tier);
+    color: var(--tier-ink);
     min-height: 38px;
   }
-  .fund:hover:not(:disabled) {
-    background: color-mix(in oklch, var(--tier) 14%, transparent);
+  .fund:not(.on):hover:not(:disabled) {
+    background: color-mix(in oklch, var(--tier) 16%, transparent);
   }
-  .fund.on {
+  .fund.on,
+  .fund.on:hover {
     background: var(--tier);
     border-color: var(--tier);
-    color: oklch(0.18 0.02 264);
+    color: oklch(0.16 0.02 264); /* fill is opaque and theme-independent, so ink is too */
+  }
+  .fund.on:hover {
+    background: color-mix(in oklch, var(--tier) 86%, white);
   }
   .fund:disabled {
     border-color: var(--border);
-    color: var(--faint);
+    color: var(--muted); /* "Short $895B" is information, not decoration */
     cursor: not-allowed;
+  }
+  .fund:focus-visible,
+  .stepper button:focus-visible,
+  .next:focus-visible,
+  .reset:focus-visible {
+    outline: 2px solid var(--tier-ink, var(--accent));
+    outline-offset: 2px;
   }
 
   .stepper {
@@ -592,7 +620,7 @@
     padding: 3px;
   }
   .stepper.on {
-    border-color: var(--tier);
+    border-color: var(--tier-ink);
   }
   .stepper button {
     width: 32px;
@@ -600,15 +628,16 @@
     border: 0;
     border-radius: 5px;
     background: transparent;
-    color: var(--tier);
+    color: var(--tier-ink);
     font-size: 16px;
     line-height: 1;
   }
   .stepper button:hover:not(:disabled) {
-    background: color-mix(in oklch, var(--tier) 14%, transparent);
+    background: color-mix(in oklch, var(--tier) 16%, transparent);
   }
   .stepper button:disabled {
-    color: var(--faint);
+    color: var(--muted); /* --faint lands near 3:1 on both surfaces; still reads as off */
+    opacity: 0.75;
     cursor: not-allowed;
   }
   .years {
@@ -641,7 +670,7 @@
     text-decoration: none;
   }
   .sources a:hover {
-    color: var(--tier);
+    color: var(--tier-ink);
   }
 
   .tier-foot {
@@ -658,18 +687,18 @@
     color: var(--muted);
   }
   .tally strong {
-    color: var(--tier);
+    color: var(--tier-ink);
     font-weight: 500;
   }
   .dim {
     color: var(--faint);
   }
   .next {
-    border: 1px solid var(--tier);
+    border: 1px solid var(--tier-ink);
     border-radius: 7px;
     background: color-mix(in oklch, var(--tier) 12%, transparent);
     padding: 10px 16px;
-    color: var(--tier);
+    color: var(--tier-ink);
   }
   .next:hover {
     background: color-mix(in oklch, var(--tier) 22%, transparent);
@@ -715,7 +744,7 @@
     flex: none;
     font-family: var(--font-mono);
     font-size: 13px;
-    color: var(--tier);
+    color: var(--tier-ink);
   }
 
   .totals {

--- a/src/routes/trillion/+page.svelte
+++ b/src/routes/trillion/+page.svelte
@@ -1,0 +1,919 @@
+<script lang="ts">
+  import Breadcrumbs from '$lib/components/Breadcrumbs.svelte';
+  import { allItems, tiers } from '$lib/trillion/items';
+  import {
+    FORTUNE,
+    allocations,
+    blockOwners,
+    canAfford,
+    clampUnits,
+    formatExact,
+    formatMoney,
+    formatShare,
+    itemTotal,
+    maxUnits,
+    receipt,
+    shortfall,
+    spentFraction,
+    type Item,
+    type Tier
+  } from '$lib/trillion/game';
+
+  const STORAGE_KEY = 'trillion-game';
+
+  /** One hue per tier, mid-lightness so it reads on both themes. */
+  const TIER_COLOR: Record<string, string> = {
+    toys: 'oklch(0.74 0.12 85)',
+    cheap: 'oklch(0.72 0.13 160)',
+    trophies: 'oklch(0.70 0.13 305)',
+    country: 'oklch(0.70 0.12 250)',
+    planet: 'oklch(0.74 0.11 195)',
+    moonshots: 'oklch(0.68 0.15 30)',
+    wall: 'oklch(0.62 0.03 264)'
+  };
+
+  interface Saved {
+    funded: Record<string, number>;
+    revealed: number;
+  }
+
+  const DEFAULTS: Saved = { funded: {}, revealed: 1 };
+
+  // Restored at init like the other calculators on this site, so a reload
+  // doesn't wipe out a ledger someone spent ten minutes building.
+  function restore(): Saved {
+    if (typeof window === 'undefined') return DEFAULTS;
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return DEFAULTS;
+      const parsed = JSON.parse(raw) as Partial<Saved>;
+      return {
+        funded: parsed.funded ?? {},
+        revealed: Math.min(Math.max(parsed.revealed ?? 1, 1), tiers.length)
+      };
+    } catch {
+      return DEFAULTS;
+    }
+  }
+
+  const initial = restore();
+
+  let funded = $state<Record<string, number>>(initial.funded);
+  let revealed = $state(initial.revealed);
+
+  const allocs = $derived(allocations(tiers, funded));
+  const spent = $derived(allocs.reduce((sum, a) => sum + a.amount, 0));
+  const left = $derived(FORTUNE - spent);
+  const owners = $derived(blockOwners(allocs));
+  const ledger = $derived(receipt(allocs));
+  const visibleTiers = $derived(tiers.slice(0, revealed));
+  const allRevealed = $derived(revealed >= tiers.length);
+
+  /** The most expensive thing still within reach — the receipt's parting shot. */
+  const biggestLeft = $derived(
+    allItems
+      .filter((item) => (funded[item.id] ?? 0) === 0 && item.cost <= left)
+      .sort((a, b) => b.cost - a.cost)[0]
+  );
+
+  $effect(() => {
+    const saved: Saved = { funded, revealed };
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(saved));
+    } catch {
+      // Private mode, quota, whatever — the page still works, it just forgets.
+    }
+  });
+
+  function units(item: Item): number {
+    return clampUnits(item, funded[item.id] ?? 0);
+  }
+
+  function isFunded(item: Item): boolean {
+    return units(item) > 0;
+  }
+
+  /** Money already committed to this item, which is available to re-spend on it. */
+  function budgetFor(item: Item): number {
+    return left + itemTotal(item, units(item));
+  }
+
+  function tierSpend(tier: Tier): number {
+    return tier.items.reduce((sum, item) => sum + itemTotal(item, units(item)), 0);
+  }
+
+  /** Funding anything in the last visible tier opens the next one. */
+  function revealNext(tierIndex: number) {
+    if (revealed === tierIndex + 1 && revealed < tiers.length) revealed = tierIndex + 2;
+  }
+
+  function toggle(item: Item, tierIndex: number) {
+    if (isFunded(item)) {
+      const { [item.id]: _dropped, ...rest } = funded;
+      funded = rest;
+      return;
+    }
+    if (!canAfford(item.cost, left)) return;
+    funded = { ...funded, [item.id]: 1 };
+    revealNext(tierIndex);
+  }
+
+  function bump(item: Item, delta: number, tierIndex: number) {
+    const next = clampUnits(item, units(item) + delta);
+    if (next > 0 && itemTotal(item, next) > budgetFor(item)) return;
+    if (next === 0) {
+      const { [item.id]: _dropped, ...rest } = funded;
+      funded = rest;
+      return;
+    }
+    funded = { ...funded, [item.id]: next };
+    revealNext(tierIndex);
+  }
+
+  function reset() {
+    funded = {};
+    revealed = 1;
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+</script>
+
+<svelte:head>
+  <title>Give Away Elon's Money - Martin Emde</title>
+  <meta
+    name="description"
+    content="A trillion dollars, one thousand squares, and a list of real, sourced prices for fixing things. Spend it all and watch how little moves."
+  />
+</svelte:head>
+
+<div class="page">
+  <Breadcrumbs
+    crumbs={[{ label: 'Projects', href: '/projects' }, { label: "Give Away Elon's Money" }]}
+  />
+
+  <header class="hero">
+    <div class="eyebrow">// a spending experiment</div>
+    <h1>Give Away Elon's Money</h1>
+    <p class="lede">
+      In June 2026 Elon Musk became the first person on Earth to be worth a trillion dollars. So
+      here is a trillion dollars. Your job is to get rid of it.
+    </p>
+    <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+    <p class="credit">
+      <a
+        href="https://www.forbes.com/sites/tylerroush/2026/06/29/musk-is-a-trillionaire-again-spacex-and-tesla-boost-net-worth-by-50-billion/"
+        rel="external noopener"
+        target="_blank">Forbes, June 2026 ↗</a
+      >
+    </p>
+    <p class="sub">
+      Every price below is a real, published number with a link to where it came from. This is not a
+      scoreboard for anyone's politics and nobody here owes anybody anything — it is a ruler. Most
+      people, including me, have no working intuition for what a trillion dollars is. Spend it and
+      find out.
+    </p>
+
+    <figure class="gridwrap">
+      <div class="grid" aria-hidden="true">
+        {#each owners as owner, i (i)}
+          <span class="blk" style:background={owner ? TIER_COLOR[owner] : undefined}></span>
+        {/each}
+      </div>
+      <figcaption>
+        1,000 squares. Each one is <strong>$1,000,000,000</strong> — a billion dollars. You have
+        filled
+        <strong>{Math.round(spentFraction(spent) * 1000)}</strong> of them.
+      </figcaption>
+    </figure>
+  </header>
+
+  {#each visibleTiers as tier, tierIndex (tier.id)}
+    <section class="tier" style:--tier={TIER_COLOR[tier.id]}>
+      <div class="tier-head">
+        <div class="tier-kicker">{tier.kicker}</div>
+        <h2>{tier.title}</h2>
+        <p>{tier.lede}</p>
+      </div>
+
+      <div class="cards">
+        {#each tier.items as item (item.id)}
+          {@const n = units(item)}
+          {@const committed = itemTotal(item, n)}
+          {@const affordable = canAfford(item.cost, budgetFor(item))}
+          {@const short = shortfall(item.cost, budgetFor(item))}
+          <article class="card" class:funded={n > 0} class:broke={!affordable && n === 0}>
+            <div class="card-top">
+              <h3>{item.label}</h3>
+              <div class="price">
+                {formatMoney(item.cost)}{#if item.per}<span class="per">/yr</span>{/if}
+              </div>
+            </div>
+
+            <p class="why">{item.note}</p>
+
+            <div class="card-foot">
+              {#if item.per}
+                <div class="stepper" class:on={n > 0}>
+                  <button
+                    type="button"
+                    onclick={() => bump(item, -1, tierIndex)}
+                    disabled={n === 0}
+                    aria-label="Fund {item.label} for one year less">−</button
+                  >
+                  <span class="years">
+                    {#if n === 0}
+                      Fund by the year
+                    {:else}
+                      {n}
+                      {n === 1 ? 'year' : 'years'} · {formatMoney(committed)}
+                    {/if}
+                  </span>
+                  <button
+                    type="button"
+                    onclick={() => bump(item, 1, tierIndex)}
+                    disabled={n >= maxUnits(item) || itemTotal(item, n + 1) > budgetFor(item)}
+                    aria-label="Fund {item.label} for one more year">+</button
+                  >
+                </div>
+              {:else}
+                <button
+                  type="button"
+                  class="fund"
+                  class:on={n > 0}
+                  disabled={!affordable && n === 0}
+                  onclick={() => toggle(item, tierIndex)}
+                >
+                  {#if n > 0}
+                    Funded — undo
+                  {:else if affordable}
+                    Fund it
+                  {:else}
+                    Short {formatMoney(short)}
+                  {/if}
+                </button>
+              {/if}
+
+              <div class="share">
+                {#if n > 0}
+                  {formatShare(committed)} of the fortune
+                {:else}
+                  {formatShare(item.cost)}{#if item.per}&nbsp;a year{/if}
+                {/if}
+              </div>
+            </div>
+
+            <!-- Prices come from the linked sources; the rule can't see that these are external. -->
+            <!-- eslint-disable svelte/no-navigation-without-resolve -->
+            <div class="sources">
+              {#each item.sources as source (source.url)}
+                <a href={source.url} rel="external noopener" target="_blank">{source.label} ↗</a>
+              {/each}
+            </div>
+            <!-- eslint-enable svelte/no-navigation-without-resolve -->
+          </article>
+        {/each}
+      </div>
+
+      <div class="tier-foot">
+        <span class="tally">
+          This tier: <strong>{formatMoney(tierSpend(tier))}</strong>
+          <span class="dim">· {formatShare(tierSpend(tier))} of the trillion</span>
+        </span>
+        {#if tierIndex === revealed - 1 && !allRevealed}
+          <button type="button" class="next" onclick={() => (revealed += 1)}>
+            Next: {tiers[tierIndex + 1].title} ↓
+          </button>
+        {/if}
+      </div>
+    </section>
+  {/each}
+
+  {#if allRevealed}
+    <section class="finale">
+      <h2>The receipt</h2>
+
+      {#if ledger.length === 0}
+        <p class="empty">
+          You haven't spent a dollar yet. The whole trillion is still sitting up there.
+        </p>
+      {:else}
+        <ol class="ledger">
+          {#each ledger as alloc (alloc.item.id)}
+            <li style:--tier={TIER_COLOR[alloc.tierId]}>
+              <span class="l-name">
+                {alloc.item.label}{#if alloc.units > 1}
+                  <span class="dim"> × {alloc.units} years</span>{/if}
+              </span>
+              <span class="l-amount">{formatMoney(alloc.amount)}</span>
+            </li>
+          {/each}
+        </ol>
+
+        <div class="totals">
+          <div>
+            <span class="t-label">Allocated</span>
+            <span class="t-value">{formatExact(spent)}</span>
+            <span class="t-note"
+              >{formatShare(spent)} of the fortune, across {ledger.length}
+              {ledger.length === 1 ? 'line' : 'lines'}</span
+            >
+          </div>
+          <div>
+            <span class="t-label">Still in the pile</span>
+            <span class="t-value">{formatExact(left)}</span>
+            <span class="t-note">
+              {#if left <= 0}
+                Gone. Every square is full.
+              {:else if biggestLeft}
+                Still enough for: {biggestLeft.label.toLowerCase()} ({formatMoney(
+                  biggestLeft.cost
+                )}{#if biggestLeft.per}/yr{/if})
+              {:else}
+                Not enough left for anything else on this list.
+              {/if}
+            </span>
+          </div>
+        </div>
+      {/if}
+
+      <div class="closers">
+        <h3>Three ways to hold the number</h3>
+        <p>
+          <strong>Spend a million dollars a day.</strong> Start the day Julius Caesar was assassinated
+          and keep going, weekends included, for 2,070 years. You would be about $240 billion short of
+          a trillion.
+        </p>
+        <p>
+          <strong>Count to a trillion out loud</strong>, one number a second, without sleeping. You
+          finish in roughly 31,700 years.
+        </p>
+        <p>
+          <strong>It moves faster than you can spend it.</strong> Forbes clocked this particular fortune
+          gaining about $60 billion in a single week in June 2026 — enough, in seven days, to end polio,
+          immunize half a billion children, fully fund the global fight against AIDS, TB and malaria,
+          replace every lead pipe in America, and still have $4 billion left over.
+        </p>
+      </div>
+
+      <div class="fineprint">
+        <p>
+          Every figure links to its source. Global estimates are estimates: the underlying research
+          usually gives a range, and where it does, these prices use a number the cited source
+          itself leads with. Sports valuations are Forbes' 2025 marks, not offers — nobody has to
+          sell. Recurring costs are shown per year because that is how their budgets are actually
+          written.
+        </p>
+        <button type="button" class="reset" onclick={reset}>Put it all back</button>
+      </div>
+    </section>
+  {/if}
+
+  <!-- Sticky rather than fixed: it rides the viewport bottom while you spend,
+       then settles at the end of the page instead of sitting on the footer. -->
+  <aside class="hud" aria-live="polite">
+    <div class="hud-inner">
+      <div class="hud-main">
+        <span class="hud-label">Still to spend</span>
+        <span class="hud-amount">{formatExact(left)}</span>
+      </div>
+      <div class="hud-bar">
+        <div class="hud-fill" style:width="{spentFraction(spent) * 100}%"></div>
+      </div>
+      <div class="hud-meta">
+        <span>{formatShare(spent)} allocated</span>
+        <span>{ledger.length} funded</span>
+      </div>
+    </div>
+  </aside>
+</div>
+
+<style>
+  .page {
+    padding-bottom: 8px;
+  }
+
+  /* ---- Hero ------------------------------------------------------------ */
+  .hero {
+    padding: 8px 0 40px;
+  }
+  h1 {
+    margin: 14px 0 18px;
+    font-family: var(--font-body);
+    font-weight: 600;
+    font-size: 40px;
+    line-height: 1.03;
+    letter-spacing: -0.03em;
+    color: var(--text); /* Skeleton's h1 preset tints headings; the page wants ink */
+  }
+  .lede {
+    margin: 0 0 14px;
+    max-width: 620px;
+    font-size: 18px;
+    line-height: 1.6;
+    text-wrap: pretty;
+  }
+  .credit {
+    margin: 0 0 16px;
+  }
+  .credit a {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--faint);
+    text-decoration: none;
+  }
+  .credit a:hover {
+    color: var(--accent);
+  }
+  .sub {
+    margin: 0;
+    max-width: 620px;
+    font-size: 15px;
+    line-height: 1.7;
+    color: var(--muted);
+    text-wrap: pretty;
+  }
+
+  .gridwrap {
+    margin: 32px 0 0;
+  }
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(25, 1fr);
+    gap: 2px;
+    max-width: 520px;
+  }
+  .blk {
+    aspect-ratio: 1;
+    border-radius: 1px;
+    background: color-mix(in oklch, var(--border) 70%, transparent);
+    transition: background 180ms ease;
+  }
+  .gridwrap figcaption {
+    margin-top: 14px;
+    max-width: 520px;
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    line-height: 1.7;
+    color: var(--faint);
+  }
+  .gridwrap strong {
+    color: var(--text);
+    font-weight: 500;
+  }
+
+  /* ---- Tiers ----------------------------------------------------------- */
+  .tier {
+    border-top: 1px solid var(--border);
+    padding: 40px 0 8px;
+  }
+  .tier-kicker {
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--tier);
+  }
+  .tier-head h2 {
+    margin: 10px 0 12px;
+    font-family: var(--font-body);
+    font-weight: 600;
+    font-size: 28px;
+    letter-spacing: -0.02em;
+    line-height: 1.1;
+    color: var(--text);
+  }
+  .tier-head p {
+    margin: 0 0 26px;
+    max-width: 620px;
+    font-size: 15.5px;
+    line-height: 1.7;
+    color: var(--muted);
+    text-wrap: pretty;
+  }
+
+  .cards {
+    display: grid;
+    gap: 12px;
+  }
+  .card {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    border: 1px solid var(--border);
+    border-left: 3px solid color-mix(in oklch, var(--border) 80%, transparent);
+    border-radius: 10px;
+    background: var(--surface);
+    padding: 16px;
+  }
+  .card.funded {
+    border-left-color: var(--tier);
+    background: color-mix(in oklch, var(--tier) 7%, var(--surface));
+  }
+  .card.broke {
+    opacity: 0.62;
+  }
+  .card-top {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 14px;
+  }
+  .card-top h3 {
+    margin: 0;
+    font-family: var(--font-body);
+    font-weight: 560;
+    font-size: 16.5px;
+    line-height: 1.3;
+    letter-spacing: -0.01em;
+    color: var(--text);
+  }
+  .price {
+    flex: none;
+    font-family: var(--font-mono);
+    font-weight: 500;
+    font-size: 16px;
+    color: var(--tier);
+    white-space: nowrap;
+  }
+  .per {
+    font-size: 11px;
+    color: var(--faint);
+  }
+  .why {
+    margin: 0;
+    font-size: 13.5px;
+    line-height: 1.65;
+    color: var(--muted);
+    text-wrap: pretty;
+  }
+
+  .card-foot {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+  }
+  .fund,
+  .stepper button,
+  .next,
+  .reset {
+    font-family: var(--font-mono);
+    font-size: 12.5px;
+    cursor: pointer;
+  }
+  .fund {
+    border: 1px solid var(--tier);
+    border-radius: 7px;
+    background: transparent;
+    padding: 8px 15px;
+    color: var(--tier);
+    min-height: 38px;
+  }
+  .fund:hover:not(:disabled) {
+    background: color-mix(in oklch, var(--tier) 14%, transparent);
+  }
+  .fund.on {
+    background: var(--tier);
+    border-color: var(--tier);
+    color: oklch(0.18 0.02 264);
+  }
+  .fund:disabled {
+    border-color: var(--border);
+    color: var(--faint);
+    cursor: not-allowed;
+  }
+
+  .stepper {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    border: 1px solid var(--border);
+    border-radius: 7px;
+    padding: 3px;
+  }
+  .stepper.on {
+    border-color: var(--tier);
+  }
+  .stepper button {
+    width: 32px;
+    height: 32px;
+    border: 0;
+    border-radius: 5px;
+    background: transparent;
+    color: var(--tier);
+    font-size: 16px;
+    line-height: 1;
+  }
+  .stepper button:hover:not(:disabled) {
+    background: color-mix(in oklch, var(--tier) 14%, transparent);
+  }
+  .stepper button:disabled {
+    color: var(--faint);
+    cursor: not-allowed;
+  }
+  .years {
+    min-width: 128px;
+    text-align: center;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--muted);
+  }
+  .stepper.on .years {
+    color: var(--text);
+  }
+
+  .share {
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    color: var(--faint);
+  }
+  .sources {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px;
+    border-top: 1px solid color-mix(in oklch, var(--border) 60%, transparent);
+    padding-top: 10px;
+  }
+  .sources a {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--faint);
+    text-decoration: none;
+  }
+  .sources a:hover {
+    color: var(--tier);
+  }
+
+  .tier-foot {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 14px;
+    padding: 22px 2px 8px;
+  }
+  .tally {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--muted);
+  }
+  .tally strong {
+    color: var(--tier);
+    font-weight: 500;
+  }
+  .dim {
+    color: var(--faint);
+  }
+  .next {
+    border: 1px solid var(--tier);
+    border-radius: 7px;
+    background: color-mix(in oklch, var(--tier) 12%, transparent);
+    padding: 10px 16px;
+    color: var(--tier);
+  }
+  .next:hover {
+    background: color-mix(in oklch, var(--tier) 22%, transparent);
+  }
+
+  /* ---- Finale ---------------------------------------------------------- */
+  .finale {
+    border-top: 1px solid var(--border);
+    padding: 40px 0 0;
+  }
+  .finale h2 {
+    margin: 0 0 20px;
+    font-family: var(--font-body);
+    font-weight: 600;
+    font-size: 28px;
+    letter-spacing: -0.02em;
+    color: var(--text);
+  }
+  .empty {
+    font-size: 15px;
+    color: var(--muted);
+  }
+  .ledger {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    border-top: 1px solid var(--border);
+  }
+  .ledger li {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 16px;
+    border-bottom: 1px solid var(--border);
+    border-left: 3px solid var(--tier);
+    padding: 11px 12px;
+  }
+  .l-name {
+    font-size: 14px;
+    line-height: 1.4;
+  }
+  .l-amount {
+    flex: none;
+    font-family: var(--font-mono);
+    font-size: 13px;
+    color: var(--tier);
+  }
+
+  .totals {
+    display: grid;
+    gap: 12px;
+    margin-top: 22px;
+  }
+  .totals > div {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface);
+    padding: 16px;
+  }
+  .t-label {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--faint);
+  }
+  .t-value {
+    font-family: var(--font-mono);
+    font-size: clamp(19px, 5.4vw, 27px);
+    font-variant-numeric: tabular-nums;
+    letter-spacing: -0.02em;
+    color: var(--accent);
+  }
+  .t-note {
+    font-size: 12.5px;
+    color: var(--muted);
+  }
+
+  .closers {
+    margin-top: 40px;
+    border-top: 1px solid var(--border);
+    padding-top: 28px;
+  }
+  .closers h3 {
+    margin: 0 0 16px;
+    font-family: var(--font-body);
+    font-weight: 560;
+    font-size: 19px;
+    color: var(--text);
+  }
+  .closers p {
+    margin: 0 0 16px;
+    max-width: 640px;
+    font-size: 15px;
+    line-height: 1.7;
+    color: var(--muted);
+    text-wrap: pretty;
+  }
+  .closers strong {
+    color: var(--text);
+    font-weight: 560;
+  }
+
+  .fineprint {
+    margin-top: 20px;
+    border-top: 1px solid var(--border);
+    padding: 22px 0 8px;
+  }
+  .fineprint p {
+    margin: 0 0 20px;
+    max-width: 640px;
+    font-size: 12.5px;
+    line-height: 1.7;
+    color: var(--faint);
+  }
+  .reset {
+    border: 1px solid var(--border);
+    border-radius: 7px;
+    background: transparent;
+    padding: 10px 16px;
+    color: var(--muted);
+  }
+  .reset:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+
+  /* ---- The wallet ------------------------------------------------------ */
+  .hud {
+    position: sticky;
+    bottom: 0;
+    z-index: 30;
+    margin: 28px -20px 0;
+    border-top: 1px solid var(--border);
+    background: color-mix(in oklch, var(--bg) 92%, transparent);
+    backdrop-filter: saturate(1.2) blur(10px);
+  }
+  .hud-inner {
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+    padding: 11px 20px calc(11px + env(safe-area-inset-bottom));
+  }
+  .hud-main {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+  }
+  .hud-label {
+    flex: none;
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--faint);
+  }
+  .hud-amount {
+    font-family: var(--font-mono);
+    font-size: clamp(17px, 5.2vw, 26px);
+    font-variant-numeric: tabular-nums;
+    letter-spacing: -0.02em;
+    color: var(--accent);
+  }
+  .hud-bar {
+    height: 4px;
+    border-radius: 2px;
+    background: color-mix(in oklch, var(--border) 80%, transparent);
+    overflow: hidden;
+  }
+  .hud-fill {
+    height: 100%;
+    border-radius: 2px;
+    background: var(--accent);
+    transition: width 260ms ease;
+  }
+  .hud-meta {
+    display: flex;
+    justify-content: space-between;
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--faint);
+  }
+
+  /* ---- Wider screens --------------------------------------------------- */
+  @media (min-width: 720px) {
+    .hero {
+      padding-top: 24px;
+    }
+    h1 {
+      font-size: 54px;
+    }
+    .lede {
+      font-size: 20px;
+    }
+    .grid {
+      grid-template-columns: repeat(50, 1fr);
+      gap: 3px;
+      max-width: 100%;
+    }
+    .gridwrap figcaption {
+      max-width: 100%;
+      font-size: 12px;
+    }
+    .cards {
+      grid-template-columns: 1fr 1fr;
+    }
+    .card {
+      padding: 18px;
+    }
+    .tier-head h2,
+    .finale h2 {
+      font-size: 34px;
+    }
+    .totals {
+      grid-template-columns: 1fr 1fr;
+    }
+    .hud {
+      margin: 32px -32px 0;
+    }
+    .hud-inner {
+      flex-direction: row;
+      align-items: center;
+      gap: 20px;
+      padding: 13px 32px;
+    }
+    .hud-main {
+      flex: none;
+    }
+    .hud-bar {
+      flex: 1;
+    }
+    .hud-meta {
+      flex: none;
+      gap: 18px;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .blk,
+    .hud-fill {
+      transition: none;
+    }
+  }
+</style>

--- a/src/routes/trillion/+page.svelte
+++ b/src/routes/trillion/+page.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import Breadcrumbs from '$lib/components/Breadcrumbs.svelte';
-  import { allItems, tiers } from '$lib/trillion/items';
+  import { allItems, bankrolls, tiers } from '$lib/trillion/items';
   import {
-    FORTUNE,
     allocations,
+    bankrollAt,
     blockOwners,
+    blockValue,
     canAfford,
     clampUnits,
     formatExact,
@@ -12,6 +13,9 @@
     formatShare,
     itemTotal,
     maxUnits,
+    needsUpgrade,
+    overdraft,
+    rungFor,
     receipt,
     shortfall,
     spentFraction,
@@ -35,9 +39,11 @@
   interface Saved {
     funded: Record<string, number>;
     revealed: number;
+    /** Which bankroll is open: 0 is Musk alone, the last rung is the red. */
+    level: number;
   }
 
-  const DEFAULTS: Saved = { funded: {}, revealed: 1 };
+  const DEFAULTS: Saved = { funded: {}, revealed: 1, level: 0 };
 
   // Restored at init like the other calculators on this site, so a reload
   // doesn't wipe out a ledger someone spent ten minutes building.
@@ -49,7 +55,8 @@
       const parsed = JSON.parse(raw) as Partial<Saved>;
       return {
         funded: parsed.funded ?? {},
-        revealed: Math.min(Math.max(parsed.revealed ?? 1, 1), tiers.length)
+        revealed: Math.min(Math.max(parsed.revealed ?? 1, 1), tiers.length),
+        level: Math.min(Math.max(parsed.level ?? 0, 0), bankrolls.length - 1)
       };
     } catch {
       return DEFAULTS;
@@ -60,14 +67,37 @@
 
   let funded = $state<Record<string, number>>(initial.funded);
   let revealed = $state(initial.revealed);
+  let level = $state(initial.level);
+
+  /** The item waiting on an upgrade, and how many years of it. Drives the modal. */
+  let pending = $state<{ item: Item; units: number; tierIndex: number } | null>(null);
+  let modal = $state<HTMLDialogElement | null>(null);
+
+  const bankroll = $derived(bankrollAt(bankrolls, level));
+  const pot = $derived(bankroll.amount);
 
   const allocs = $derived(allocations(tiers, funded));
   const spent = $derived(allocs.reduce((sum, a) => sum + a.amount, 0));
-  const left = $derived(FORTUNE - spent);
-  const owners = $derived(blockOwners(allocs));
+  const left = $derived(pot - spent);
+  const inTheRed = $derived(overdraft(spent, pot));
+  const owners = $derived(blockOwners(allocs, pot));
   const ledger = $derived(receipt(allocs));
   const visibleTiers = $derived(tiers.slice(0, revealed));
   const allRevealed = $derived(revealed >= tiers.length);
+
+  /** Which rung the parked purchase actually needs, not merely the next one up. */
+  const upgradeLevel = $derived(
+    pending
+      ? rungFor(
+          bankrolls,
+          level,
+          spent -
+            itemTotal(pending.item, units(pending.item)) +
+            itemTotal(pending.item, pending.units)
+        )
+      : level + 1
+  );
+  const upgrade = $derived(bankrolls[upgradeLevel]);
 
   /** The most expensive thing still within reach — the receipt's parting shot. */
   const biggestLeft = $derived(
@@ -77,7 +107,7 @@
   );
 
   $effect(() => {
-    const saved: Saved = { funded, revealed };
+    const saved: Saved = { funded, revealed, level };
     try {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(saved));
     } catch {
@@ -107,32 +137,58 @@
     if (revealed === tierIndex + 1 && revealed < tiers.length) revealed = tierIndex + 2;
   }
 
+  /** Commits a purchase, or parks it and asks for a bigger bankroll first. */
+  function spend(item: Item, nextUnits: number, tierIndex: number) {
+    const cost = itemTotal(item, nextUnits) - itemTotal(item, units(item));
+    if (needsUpgrade(cost, left, bankrolls, level)) {
+      pending = { item, units: nextUnits, tierIndex };
+      modal?.showModal();
+      return;
+    }
+    if (!canAfford(cost, left, bankroll.unlimited)) return;
+    funded = { ...funded, [item.id]: nextUnits };
+    revealNext(tierIndex);
+  }
+
   function toggle(item: Item, tierIndex: number) {
     if (isFunded(item)) {
       const { [item.id]: _dropped, ...rest } = funded;
       funded = rest;
       return;
     }
-    if (!canAfford(item.cost, left)) return;
-    funded = { ...funded, [item.id]: 1 };
-    revealNext(tierIndex);
+    spend(item, 1, tierIndex);
   }
 
   function bump(item: Item, delta: number, tierIndex: number) {
     const next = clampUnits(item, units(item) + delta);
-    if (next > 0 && itemTotal(item, next) > budgetFor(item)) return;
     if (next === 0) {
       const { [item.id]: _dropped, ...rest } = funded;
       funded = rest;
       return;
     }
-    funded = { ...funded, [item.id]: next };
-    revealNext(tierIndex);
+    spend(item, next, tierIndex);
+  }
+
+  /** Take the bankroll the purchase needs and put it through. */
+  function acceptUpgrade() {
+    level = Math.min(Math.max(upgradeLevel, level), bankrolls.length - 1);
+    if (pending) {
+      funded = { ...funded, [pending.item.id]: pending.units };
+      revealNext(pending.tierIndex);
+    }
+    closeModal();
+  }
+
+  function closeModal() {
+    pending = null;
+    modal?.close();
   }
 
   function reset() {
     funded = {};
     revealed = 1;
+    level = 0;
+    closeModal();
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }
 </script>
@@ -169,7 +225,7 @@
       Every price below is a real, published number with a link to where it came from. This is not a
       scoreboard for anyone's politics and nobody here owes anybody anything — it is a ruler. Most
       people, including me, have no working intuition for what a trillion dollars is. Spend it and
-      find out.
+      find out. Run out, and you'll be offered somebody else's money.
     </p>
 
     <figure class="gridwrap">
@@ -179,9 +235,13 @@
         {/each}
       </div>
       <figcaption>
-        1,000 squares. Each one is <strong>$1,000,000,000</strong> — a billion dollars. You have
-        filled
-        <strong>{Math.round(spentFraction(spent) * 1000)}</strong> of them.
+        1,000 squares. Each one is <strong>{formatExact(blockValue(pot))}</strong>. You have filled
+        <strong>{Math.round(spentFraction(spent, pot) * 1000)}</strong> of them.
+        {#if level > 0}
+          <span class="rescaled">
+            The grid did not get bigger when you took {bankroll.label} — the squares did.
+          </span>
+        {/if}
       </figcaption>
     </figure>
   </header>
@@ -198,8 +258,9 @@
         {#each tier.items as item (item.id)}
           {@const n = units(item)}
           {@const committed = itemTotal(item, n)}
-          {@const affordable = canAfford(item.cost, budgetFor(item))}
+          {@const affordable = canAfford(item.cost, budgetFor(item), bankroll.unlimited)}
           {@const short = shortfall(item.cost, budgetFor(item))}
+          {@const askable = needsUpgrade(item.cost, budgetFor(item), bankrolls, level)}
           <article class="card" class:funded={n > 0} class:broke={!affordable && n === 0}>
             <div class="card-top">
               <h3>{item.label}</h3>
@@ -230,7 +291,10 @@
                   <button
                     type="button"
                     onclick={() => bump(item, 1, tierIndex)}
-                    disabled={n >= maxUnits(item) || itemTotal(item, n + 1) > budgetFor(item)}
+                    disabled={n >= maxUnits(item) ||
+                      (itemTotal(item, n + 1) > budgetFor(item) &&
+                        !bankroll.unlimited &&
+                        !needsUpgrade(itemTotal(item, n + 1) - committed, left, bankrolls, level))}
                     aria-label="Fund {item.label} for one more year">+</button
                   >
                 </div>
@@ -239,13 +303,16 @@
                   type="button"
                   class="fund"
                   class:on={n > 0}
-                  disabled={!affordable && n === 0}
+                  class:ask={askable && n === 0}
+                  disabled={!affordable && !askable && n === 0}
                   onclick={() => toggle(item, tierIndex)}
                 >
                   {#if n > 0}
                     Funded — undo
                   {:else if affordable}
                     Fund it
+                  {:else if askable}
+                    Needs {formatMoney(short)} more →
                   {:else}
                     Short {formatMoney(short)}
                   {/if}
@@ -254,9 +321,9 @@
 
               <div class="share">
                 {#if n > 0}
-                  {formatShare(committed)} of the fortune
+                  {formatShare(committed, pot)} of the pot
                 {:else}
-                  {formatShare(item.cost)}{#if item.per}&nbsp;a year{/if}
+                  {formatShare(item.cost, pot)}{#if item.per}&nbsp;a year{/if}
                 {/if}
               </div>
             </div>
@@ -276,7 +343,7 @@
       <div class="tier-foot">
         <span class="tally">
           This tier: <strong>{formatMoney(tierSpend(tier))}</strong>
-          <span class="dim">· {formatShare(tierSpend(tier))} of the trillion</span>
+          <span class="dim">· {formatShare(tierSpend(tier), pot)} of the pot</span>
         </span>
         {#if tierIndex === revealed - 1 && !allRevealed}
           <button type="button" class="next" onclick={() => (revealed += 1)}>
@@ -318,10 +385,12 @@
             >
           </div>
           <div>
-            <span class="t-label">Still in the pile</span>
-            <span class="t-value">{formatExact(left)}</span>
+            <span class="t-label">{inTheRed > 0 ? 'Overdrawn by' : 'Still in the pile'}</span>
+            <span class="t-value" class:red={inTheRed > 0}>{formatExact(Math.abs(left))}</span>
             <span class="t-note">
-              {#if left <= 0}
+              {#if inTheRed > 0}
+                Past every billionaire on Earth. This money does not exist.
+              {:else if left <= 0}
                 Gone. Every square is full.
               {:else if biggestLeft}
                 Still enough for: {biggestLeft.label.toLowerCase()} ({formatMoney(
@@ -372,19 +441,73 @@
   <aside class="hud" aria-live="polite">
     <div class="hud-inner">
       <div class="hud-main">
-        <span class="hud-label">Still to spend</span>
-        <span class="hud-amount">{formatExact(left)}</span>
+        <span class="hud-label">{inTheRed > 0 ? 'Overdrawn' : 'Still to spend'}</span>
+        <span class="hud-amount" class:red={inTheRed > 0}
+          >{inTheRed > 0 ? '−' : ''}{formatExact(Math.abs(left))}</span
+        >
       </div>
       <div class="hud-bar">
-        <div class="hud-fill" style:width="{spentFraction(spent) * 100}%"></div>
+        <div
+          class="hud-fill"
+          class:red={inTheRed > 0}
+          style:width="{spentFraction(spent, pot) * 100}%"
+        ></div>
       </div>
       <div class="hud-meta">
-        <span>{formatShare(spent)} allocated</span>
+        <span>bankroll: {bankroll.short}</span>
         <span>{ledger.length} funded</span>
       </div>
     </div>
   </aside>
 </div>
+
+<!-- Native <dialog> so focus trapping, Escape and the backdrop come for free. -->
+<dialog bind:this={modal} class="ask-modal" onclose={() => (pending = null)}>
+  {#if pending && upgrade}
+    {@const cost = itemTotal(pending.item, pending.units)}
+    <h2>{bankroll.exhausted}</h2>
+    <p class="ask-lede">
+      <strong>{pending.item.label}</strong>
+      {#if pending.units > 1}for {pending.units} years{/if}
+      costs {formatMoney(cost)} — {formatMoney(shortfall(cost, left))} more than is left in the pot.
+    </p>
+
+    <div class="ask-next">
+      <div class="ask-next-head">
+        <span class="ask-next-label">Next up: {upgrade.label}</span>
+        <span class="ask-next-amount">
+          {upgrade.unlimited ? 'no limit' : formatMoney(upgrade.amount)}
+        </span>
+      </div>
+      <p class="ask-note">{upgrade.note}</p>
+      {#if !upgrade.unlimited}
+        <p class="ask-people">
+          {upgrade.people} · each square in the grid becomes {formatMoney(
+            blockValue(upgrade.amount)
+          )}
+        </p>
+      {/if}
+      <!-- eslint-disable svelte/no-navigation-without-resolve -->
+      <div class="ask-sources">
+        {#each upgrade.sources as source (source.url)}
+          <a href={source.url} rel="external noopener" target="_blank">{source.label} ↗</a>
+        {/each}
+      </div>
+      <!-- eslint-enable svelte/no-navigation-without-resolve -->
+    </div>
+
+    <div class="ask-actions">
+      <button type="button" class="ask-yes" onclick={acceptUpgrade}>
+        {#if upgrade.unlimited}
+          Go into the red
+        {:else}
+          Spend theirs too
+        {/if}
+      </button>
+      <button type="button" class="ask-no" onclick={closeModal}>Never mind</button>
+    </div>
+  {/if}
+</dialog>
 
 <style>
   .page {
@@ -458,6 +581,11 @@
   .gridwrap strong {
     color: var(--text);
     font-weight: 500;
+  }
+  .rescaled {
+    display: block;
+    margin-top: 4px;
+    color: var(--accent2);
   }
 
   /* ---- Tiers ----------------------------------------------------------- */
@@ -597,6 +725,16 @@
   }
   .fund.on:hover {
     background: color-mix(in oklch, var(--tier) 86%, white);
+  }
+  /* An unaffordable price is an invitation to open a bigger bankroll, so it
+     reads as an action rather than a dead control. */
+  .fund.ask {
+    border-style: dashed;
+    color: var(--tier-ink);
+  }
+  .fund.ask:hover {
+    background: color-mix(in oklch, var(--tier) 16%, transparent);
+    border-style: solid;
   }
   .fund:disabled {
     border-color: var(--border);
@@ -877,12 +1015,138 @@
     background: var(--accent);
     transition: width 260ms ease;
   }
+  .hud-amount.red,
+  .t-value.red {
+    color: light-dark(oklch(0.5 0.2 25), oklch(0.75 0.17 25));
+  }
+  .hud-fill.red {
+    background: light-dark(oklch(0.5 0.2 25), oklch(0.75 0.17 25));
+  }
   .hud-meta {
     display: flex;
     justify-content: space-between;
     font-family: var(--font-mono);
     font-size: 10.5px;
     color: var(--faint);
+  }
+
+  /* ---- The bigger-bankroll modal --------------------------------------- */
+  .ask-modal {
+    width: min(520px, calc(100vw - 32px));
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    background: var(--bg);
+    padding: 24px 20px 20px;
+    color: var(--text);
+  }
+  .ask-modal::backdrop {
+    background: oklch(0.12 0.02 264 / 0.66);
+    backdrop-filter: blur(3px);
+  }
+  .ask-modal h2 {
+    margin: 0 0 12px;
+    font-family: var(--font-body);
+    font-weight: 600;
+    font-size: 23px;
+    line-height: 1.15;
+    letter-spacing: -0.02em;
+    color: var(--text);
+    text-wrap: balance;
+  }
+  .ask-lede {
+    margin: 0 0 18px;
+    font-size: 14.5px;
+    line-height: 1.6;
+    color: var(--muted);
+    text-wrap: pretty;
+  }
+  .ask-lede strong {
+    color: var(--text);
+    font-weight: 560;
+  }
+  .ask-next {
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface);
+    padding: 14px;
+  }
+  .ask-next-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 8px;
+  }
+  .ask-next-label {
+    font-family: var(--font-body);
+    font-weight: 560;
+    font-size: 15px;
+  }
+  .ask-next-amount {
+    flex: none;
+    font-family: var(--font-mono);
+    font-size: 16px;
+    color: var(--accent);
+  }
+  .ask-note {
+    margin: 0 0 8px;
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--muted);
+    text-wrap: pretty;
+  }
+  .ask-people {
+    margin: 0 0 10px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--faint);
+  }
+  .ask-sources a {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--faint);
+    text-decoration: none;
+  }
+  .ask-sources a:hover {
+    color: var(--accent);
+  }
+  .ask-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 18px;
+  }
+  .ask-yes,
+  .ask-no {
+    border-radius: 8px;
+    padding: 12px 16px;
+    font-family: var(--font-mono);
+    font-size: 13px;
+    cursor: pointer;
+    min-height: 44px;
+  }
+  .ask-yes {
+    flex: 1;
+    border: 1px solid var(--accent);
+    background: var(--accent);
+    color: light-dark(oklch(0.99 0 0), oklch(0.16 0.02 264));
+  }
+  .ask-yes:hover {
+    background: color-mix(in oklch, var(--accent) 86%, white);
+  }
+  .ask-no {
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--muted);
+  }
+  .ask-no:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+  .ask-yes:focus-visible,
+  .ask-no:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
   }
 
   /* ---- Wider screens --------------------------------------------------- */

--- a/src/routes/trillion/+page.ts
+++ b/src/routes/trillion/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;


### PR DESCRIPTION
A new project at /trillion. You start with a trillion dollars and
allocate it across 36 real, sourced line items, arranged in seven tiers
that escalate from a superyacht to the annual cost of the global energy
transition. The point is scale: the tier that cures blindness, ends
polio and immunizes half a billion children costs less than a third of
what every NFL franchise does, and the last tier can't be bought at all.

- src/lib/trillion/items.ts: the catalog. Every price links to a
  published source and explains its arithmetic in a note. Deliberately
  non-partisan — the subject is the size of the number.
- src/lib/trillion/game.ts: pure money math — allocation, affordability,
  the 1,000-square grid (one square = $1B), and the formatting rules,
  all unit tested.
- src/routes/trillion: mobile-first page with progressive tier reveal, a
  sticky wallet bar, per-year steppers for recurring costs, and a
  receipt at the end. State persists to localStorage.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GHgxFefJHr2Cq1Zd341Dgu