### PR TITLE
Grow the trillion grid instead of rescaling its squares

### DIFF
--- a/src/lib/trillion/game.test.ts
+++ b/src/lib/trillion/game.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import {
   BLOCKS,
+  BLOCK_VALUE,
   FORTUNE,
   allocations,
+  bands,
   bankrollAt,
+  blockCount,
   blockOwners,
-  blockValue,
   canAfford,
+  gridColumns,
   clampUnits,
   formatExact,
   formatMoney,
@@ -220,13 +223,15 @@ describe('the block grid', () => {
     expect(blockOwners([]).every((owner) => owner === null)).toBe(true);
   });
 
-  it('rescales the squares to the open bankroll', () => {
-    expect(blockValue(FORTUNE)).toBe(1_000_000_000);
-    expect(blockValue(20_100_000_000_000)).toBe(20_100_000_000);
-    // The same purchase fills fewer squares once a bigger bankroll is open.
+  it('grows the grid rather than the squares when the bankroll grows', () => {
+    expect(BLOCK_VALUE).toBe(1_000_000_000);
+    expect(blockCount(FORTUNE)).toBe(1000);
+    expect(blockCount(20_100_000_000_000)).toBe(20_100);
+    // A purchase fills the same squares no matter whose money is on the board.
     const allocs = allocations(testTiers, { one: 1 });
-    expect(blockOwners(allocs, FORTUNE).filter(Boolean)).toHaveLength(10);
-    expect(blockOwners(allocs, FORTUNE * 10).filter(Boolean)).toHaveLength(1);
+    expect(blockOwners(allocs, blockCount(FORTUNE)).filter(Boolean)).toHaveLength(10);
+    expect(blockOwners(allocs, blockCount(FORTUNE * 10)).filter(Boolean)).toHaveLength(10);
+    expect(blockOwners(allocs, blockCount(FORTUNE * 10))).toHaveLength(10_000);
   });
 
   it('colors one square per billion spent', () => {
@@ -253,6 +258,56 @@ describe('the block grid', () => {
     const owners = blockOwners([{ item: oneTime, tierId: 'a', units: 1, amount: FORTUNE * 3 }]);
     expect(owners).toHaveLength(BLOCKS);
     expect(owners.every((o) => o === 'a')).toBe(true);
+  });
+});
+
+describe('grid bands', () => {
+  it('keeps Musk’s thousand squares as a band of their own', () => {
+    const only = bands(bankrolls, 0, 1000);
+    expect(only).toHaveLength(1);
+    expect(only[0]).toMatchObject({ id: 'musk', start: 0, count: 1000 });
+
+    const two = bands(bankrolls, 1, 2600);
+    expect(two.map((b) => b.count)).toEqual([1000, 1600]);
+    expect(two[1].start).toBe(1000);
+  });
+
+  it('gives the last rung no band of its own, since it is the same money', () => {
+    const all = bands(bankrolls, bankrolls.length - 1, 20_100);
+    expect(all.map((b) => b.id)).toEqual(['musk', 'top10', 'usa', 'world']);
+    expect(all.reduce((sum, b) => sum + b.count, 0)).toBe(20_100);
+  });
+
+  it('puts the invented money in a band of its own', () => {
+    const red = bands(bankrolls, bankrolls.length - 1, 21_000).at(-1)!;
+    expect(red).toMatchObject({ id: 'red', start: 20_100, count: 900 });
+  });
+
+  it('never drops or overlaps a square', () => {
+    for (let level = 0; level < bankrolls.length; level++) {
+      const total = blockCount(bankrolls[level].amount);
+      let next = 0;
+      for (const band of bands(bankrolls, level, total)) {
+        expect(band.start).toBe(next);
+        next += band.count;
+      }
+      expect(next).toBe(total);
+    }
+  });
+});
+
+describe('grid columns', () => {
+  it('never goes below the starting layout', () => {
+    expect(gridColumns(50, 1000)).toBe(50);
+    expect(gridColumns(50, 10)).toBe(50);
+  });
+
+  it('grows slower than the grid, so the grid gets taller as well as denser', () => {
+    const rows = (count: number) => count / gridColumns(50, count);
+    expect(gridColumns(50, 20_100)).toBeGreaterThan(50);
+    expect(rows(20_100)).toBeGreaterThan(rows(1000));
+    // Twenty times the money must not mean twenty times the height.
+    expect(rows(20_100)).toBeLessThan(rows(1000) * 8);
   });
 });
 

--- a/src/lib/trillion/game.ts
+++ b/src/lib/trillion/game.ts
@@ -10,12 +10,13 @@
 export const FORTUNE = 1_000_000_000_000;
 
 /**
- * The hero grid is always 1,000 squares. At the starting bankroll each square
- * is a billion dollars; unlock a bigger bankroll and the squares get bigger
- * rather than more numerous, which is its own comment on the numbers.
+ * A square is a billion dollars and stays a billion dollars. Take a bigger
+ * bankroll and the grid grows squares rather than rescaling the ones already
+ * on the board, so Musk's trillion is still the same thousand squares it was
+ * when it was the whole game.
  */
-export const BLOCKS = 1000;
-export const BLOCK_VALUE = FORTUNE / BLOCKS;
+export const BLOCK_VALUE = 1_000_000_000;
+export const BLOCKS = FORTUNE / BLOCK_VALUE;
 
 export interface Source {
   label: string;
@@ -120,27 +121,70 @@ export function remaining(tiers: Tier[], funded: Funded): number {
   return FORTUNE - totalSpent(tiers, funded);
 }
 
-/** What one square is worth at a given bankroll. */
-export function blockValue(pot: number): number {
-  return pot / BLOCKS;
+/** How many squares a pile of money is worth. */
+export function blockCount(pot: number): number {
+  return Math.max(0, Math.round(pot / BLOCK_VALUE));
 }
 
 /**
- * Paints the 1,000-square grid. Squares are handed out in ledger order, which
- * means anything under one square's worth can fail to color a single square —
- * that is the point of the grid, not a rounding bug.
+ * Paints `count` squares. Squares are handed out in ledger order, which means
+ * anything under a billion dollars can fail to color a single square — that is
+ * the point of the grid, not a rounding bug.
  */
-export function blockOwners(allocs: Allocation[], pot: number = FORTUNE): (string | null)[] {
-  const owners: (string | null)[] = new Array(BLOCKS).fill(null);
-  const per = blockValue(pot);
+export function blockOwners(allocs: Allocation[], count: number = BLOCKS): (string | null)[] {
+  const owners: (string | null)[] = new Array(Math.max(0, count)).fill(null);
   let spent = 0;
   for (const alloc of allocs) {
-    const start = Math.floor(spent / per);
+    const start = Math.floor(spent / BLOCK_VALUE);
     spent += alloc.amount;
-    const end = Math.min(Math.floor(spent / per), BLOCKS);
+    const end = Math.min(Math.floor(spent / BLOCK_VALUE), owners.length);
     for (let i = Math.max(start, 0); i < end; i++) owners[i] = alloc.tierId;
   }
   return owners;
+}
+
+/** A run of squares in the grid and whose money put them there. */
+export interface Band {
+  /** Bankroll id, or 'red' for the squares nobody is paying for. */
+  id: string;
+  label: string;
+  /** Index into the owners array where this band starts. */
+  start: number;
+  count: number;
+}
+
+/**
+ * Splits the grid by whose money it is: Musk's original thousand squares, then
+ * one band per bankroll taken after that, then the invented money if you have
+ * overdrawn. The rules drawn between bands are the whole reason this exists —
+ * without them the trillion you started with disappears into the wall.
+ */
+export function bands(bankrolls: Bankroll[], level: number, total: number): Band[] {
+  const out: Band[] = [];
+  let start = 0;
+  for (let i = 0; i <= Math.min(level, bankrolls.length - 1); i++) {
+    const end = blockCount(bankrolls[i].amount);
+    // The last rung is the same money as the one below it — it only lifts the
+    // ceiling — so it contributes no band of its own.
+    if (end <= start) continue;
+    out.push({ id: bankrolls[i].id, label: bankrolls[i].short, start, count: end - start });
+    start = end;
+  }
+  if (total > start) {
+    out.push({ id: 'red', label: 'money that does not exist', start, count: total - start });
+  }
+  return out;
+}
+
+/**
+ * How many columns to lay the grid out in. The grid is width-bound, so height
+ * only grows if the columns grow slower than the squares do. At this exponent
+ * twenty times the money is a grid a bit under twice as tall — big enough to
+ * feel it, short enough to stay on a screen. The rules between bands do the
+ * rest of the work of showing the ratio.
+ */
+export function gridColumns(base: number, count: number): number {
+  return Math.max(base, Math.round(base * Math.pow(Math.max(count, BLOCKS) / BLOCKS, 0.4)));
 }
 
 /** Rounds to a sensible number of digits for its size: 228, 6.9, 0.45. */

--- a/src/routes/trillion/+page.svelte
+++ b/src/routes/trillion/+page.svelte
@@ -3,14 +3,18 @@
   import { allItems, bankrolls, tiers } from '$lib/trillion/items';
   import {
     allocations,
+    bands,
     bankrollAt,
+    blockCount,
     blockOwners,
-    blockValue,
+    BLOCKS,
+    BLOCK_VALUE,
     canAfford,
     clampUnits,
     formatExact,
     formatMoney,
     formatShare,
+    gridColumns,
     itemTotal,
     maxUnits,
     needsUpgrade,
@@ -80,8 +84,20 @@
   const spent = $derived(allocs.reduce((sum, a) => sum + a.amount, 0));
   const left = $derived(pot - spent);
   const inTheRed = $derived(overdraft(spent, pot));
-  const owners = $derived(blockOwners(allocs, pot));
   const ledger = $derived(receipt(allocs));
+
+  // The grid is every square the open bankroll buys, plus any square you have
+  // conjured past the last rung.
+  const squares = $derived(blockCount(Math.max(pot, spent)));
+  const owners = $derived(blockOwners(allocs, squares));
+  const gridBands = $derived(bands(bankrolls, level, squares));
+  const cols = $derived(gridColumns(25, squares));
+  const colsWide = $derived(gridColumns(50, squares));
+  // Once the squares are only a few pixels across a fat gutter is most of the
+  // grid, so the gutter thins out with them.
+  const gap = $derived(cols >= 45 ? '1px' : '2px');
+  const gapWide = $derived(colsWide >= 90 ? '1px' : colsWide >= 60 ? '2px' : '3px');
+  const filled = $derived(Math.min(blockCount(spent), squares));
   const visibleTiers = $derived(tiers.slice(0, revealed));
   const allRevealed = $derived(revealed >= tiers.length);
 
@@ -184,10 +200,17 @@
     modal?.close();
   }
 
-  function reset() {
+  /**
+   * Clears the ledger but leaves the bankroll where it is, so you can take a
+   * second run at the list with everybody's money instead of being sent back to
+   * Musk's trillion every time. `toStart` is the full wipe.
+   */
+  function reset(toStart = false) {
     funded = {};
-    revealed = 1;
-    level = 0;
+    if (toStart) {
+      revealed = 1;
+      level = 0;
+    }
     closeModal();
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }
@@ -211,7 +234,7 @@
     <h1>Give Away Elon's Money</h1>
     <p class="lede">
       In June 2026 Elon Musk became the first person on Earth to be worth a trillion dollars. So
-      here is a trillion dollars. Your job is to get rid of it.
+      here is a trillion dollars. Let's spend it.
     </p>
     <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
     <p class="credit">
@@ -222,24 +245,41 @@
       >
     </p>
     <p class="sub">
-      Every price below is a real, published number with a link to where it came from. This is not a
-      scoreboard for anyone's politics and nobody here owes anybody anything — it is a ruler. Most
-      people, including me, have no working intuition for what a trillion dollars is. Spend it and
-      find out. Run out, and you'll be offered somebody else's money.
+      Every price below is a real, published number with a link to where it came from. That doesn't
+      mean these numbers are accurate or realistic, but it gives an idea about the scale of a
+      trillion dollars. This can help you grasp what a trillion dollars actually means, so spend it
+      and find out.
     </p>
 
     <figure class="gridwrap">
-      <div class="grid" aria-hidden="true">
-        {#each owners as owner, i (i)}
-          <span class="blk" style:background={owner ? TIER_COLOR[owner] : undefined}></span>
+      <div
+        class="gridstack"
+        aria-hidden="true"
+        style:--cols={cols}
+        style:--cols-wide={colsWide}
+        style:--gap={gap}
+        style:--gap-wide={gapWide}
+      >
+        {#each gridBands as band, i (band.id)}
+          <div class="band-label" class:red={band.id === 'red'} class:ruled={i > 0}>
+            <span>{i > 0 ? '+ ' : ''}{band.label}</span>
+            <span class="band-amount">{formatMoney(band.count * BLOCK_VALUE)}</span>
+          </div>
+          <div class="grid">
+            {#each owners.slice(band.start, band.start + band.count) as owner, j (j)}
+              <span class="blk" style:background={owner ? TIER_COLOR[owner] : undefined}></span>
+            {/each}
+          </div>
         {/each}
       </div>
       <figcaption>
-        1,000 squares. Each one is <strong>{formatExact(blockValue(pot))}</strong>. You have filled
-        <strong>{Math.round(spentFraction(spent, pot) * 1000)}</strong> of them.
+        <strong>{squares.toLocaleString('en-US')}</strong> squares. Each one is
+        <strong>{formatExact(BLOCK_VALUE)}</strong> and always will be. You have filled
+        <strong>{filled.toLocaleString('en-US')}</strong> of them.
         {#if level > 0}
           <span class="rescaled">
-            The grid did not get bigger when you took {bankroll.label} — the squares did.
+            Taking {bankroll.label} did not shrink the squares — it added
+            {(squares - BLOCKS).toLocaleString('en-US')} more of them under the line.
           </span>
         {/if}
       </figcaption>
@@ -431,7 +471,20 @@
           sell. Recurring costs are shown per year because that is how their budgets are actually
           written.
         </p>
-        <button type="button" class="reset" onclick={reset}>Put it all back</button>
+        <div class="resets">
+          <button type="button" class="reset" onclick={() => reset()}>
+            {#if level > 0}
+              Put it all back, keep {bankroll.short}
+            {:else}
+              Put it all back
+            {/if}
+          </button>
+          {#if level > 0}
+            <button type="button" class="reset ghost" onclick={() => reset(true)}>
+              Start over from Elon's trillion
+            </button>
+          {/if}
+        </div>
       </div>
     </section>
   {/if}
@@ -482,9 +535,9 @@
       <p class="ask-note">{upgrade.note}</p>
       {#if !upgrade.unlimited}
         <p class="ask-people">
-          {upgrade.people} · each square in the grid becomes {formatMoney(
-            blockValue(upgrade.amount)
-          )}
+          {upgrade.people} · adds {(blockCount(upgrade.amount) - blockCount(pot)).toLocaleString(
+            'en-US'
+          )} squares to the grid
         </p>
       {/if}
       <!-- eslint-disable svelte/no-navigation-without-resolve -->
@@ -558,17 +611,47 @@
   .gridwrap {
     margin: 32px 0 0;
   }
+  /*
+   * --cols comes from the script and grows sublinearly with the square count:
+   * the squares never change value, so more money can only mean more of them,
+   * and the grid has to get denser as well as taller to stay on one screen.
+   */
+  .gridstack {
+    max-width: 520px;
+  }
   .grid {
     display: grid;
-    grid-template-columns: repeat(25, 1fr);
-    gap: 2px;
-    max-width: 520px;
+    grid-template-columns: repeat(var(--cols, 25), 1fr);
+    gap: var(--gap);
   }
   .blk {
     aspect-ratio: 1;
     border-radius: 1px;
     background: color-mix(in oklch, var(--border) 70%, transparent);
     transition: background 180ms ease;
+  }
+  /* The rule that keeps Musk's thousand squares visible inside the wall. */
+  .band-label {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    margin: 0 0 6px;
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    letter-spacing: 0.02em;
+    color: var(--faint);
+  }
+  .band-label.ruled {
+    margin-top: 14px;
+    border-top: 1px solid var(--border);
+    padding-top: 8px;
+  }
+  .band-label.red {
+    color: var(--accent2);
+    border-top-color: color-mix(in oklch, var(--accent2) 45%, transparent);
+  }
+  .band-amount {
+    margin-left: auto;
   }
   .gridwrap figcaption {
     margin-top: 14px;
@@ -955,6 +1038,11 @@
     line-height: 1.7;
     color: var(--faint);
   }
+  .resets {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
   .reset {
     border: 1px solid var(--border);
     border-radius: 7px;
@@ -964,6 +1052,14 @@
   }
   .reset:hover {
     border-color: var(--accent);
+    color: var(--accent);
+  }
+  .reset.ghost {
+    border-color: transparent;
+    color: var(--faint);
+  }
+  .reset.ghost:hover {
+    border-color: var(--border);
     color: var(--accent);
   }
 
@@ -1031,8 +1127,18 @@
   }
 
   /* ---- The bigger-bankroll modal --------------------------------------- */
+  /*
+   * `margin: auto` is the UA default for a modal dialog, but it only centers a
+   * box that fits: once the content is taller than the viewport the dialog
+   * pins to the top and overflows. Capping the height and letting it scroll
+   * keeps it centered on a short window as well as a tall one.
+   */
   .ask-modal {
+    margin: auto;
     width: min(520px, calc(100vw - 32px));
+    max-height: calc(100dvh - 48px);
+    overflow-y: auto;
+    overscroll-behavior: contain;
     border: 1px solid var(--border);
     border-radius: 14px;
     background: var(--bg);
@@ -1160,10 +1266,15 @@
     .lede {
       font-size: 20px;
     }
-    .grid {
-      grid-template-columns: repeat(50, 1fr);
-      gap: 3px;
+    .gridstack {
       max-width: 100%;
+    }
+    .grid {
+      grid-template-columns: repeat(var(--cols-wide, 50), 1fr);
+      gap: var(--gap-wide, 3px);
+    }
+    .band-label {
+      font-size: 11.5px;
     }
     .gridwrap figcaption {
       max-width: 100%;


### PR DESCRIPTION
The grid on `/trillion` used to be a fixed 1,000 squares that got *rescaled* when
you took a bigger bankroll — accept the world's money and a square silently
becomes $20B. That inverted the whole point of the page: the trillion you were
trying to build intuition for shrank into a corner of the wall, and identical
purchases painted fewer squares than they had a moment earlier.

Now a square is a billion dollars, permanently. Bigger bankrolls grow the grid
instead, and horizontal rules split it into bands — Musk's original thousand
squares, then one band per bankroll you take on top, then a red band for money
that does not exist if you overdraw. The ratio you're supposed to feel is the
thing you actually see.

**Other changes that fell out of this:**

- Column count grows sublinearly (`count^0.4`) so 20× the money is a grid a bit
  under 2× as tall rather than 20×; gutters thin as squares shrink.
- "Put it all back" now keeps your bankroll, with a separate ghost button to
  reset all the way to Musk's trillion. Being sent back to the start every time
  made re-running the list tedious.
- The upgrade modal advertises squares added rather than a new square value, and
  is capped/scrollable so it stays centered on short windows instead of pinning
  to the top and overflowing.
- Lede and intro copy toned down.

**Trade-off:** at the world's bankroll the grid is ~20,100 squares and a few
pixels across. That's legibly a wall rather than countable squares, which is the
intended read — the band rules carry the comparison, not individual squares.

Tests, `bun run lint`, and `bun run check` all pass.

Assisted-by: Claude Opus 5
