### PR TITLE
Add a shareable receipt, money-back subtext and two new tiers to /trillion

### DIFF
--- a/src/lib/trillion/game.test.ts
+++ b/src/lib/trillion/game.test.ts
@@ -8,6 +8,8 @@ import {
   blockValue,
   canAfford,
   clampUnits,
+  decodeSpend,
+  encodeSpend,
   formatExact,
   formatMoney,
   formatShare,
@@ -16,9 +18,12 @@ import {
   needsUpgrade,
   nextBankroll,
   overdraft,
+  refund,
   rungFor,
+  rungForTotal,
   receipt,
   remaining,
+  shareText,
   shortfall,
   spentFraction,
   totalSpent,
@@ -26,7 +31,7 @@ import {
   type Item,
   type Tier
 } from './game';
-import { allItems, bankrolls, tiers } from './items';
+import { allItems, bankrolls, tierColors, tiers } from './items';
 
 const oneTime: Item = {
   id: 'one',
@@ -126,6 +131,8 @@ describe('bankrolls', () => {
       label: 'A',
       short: 'A',
       people: '1',
+      count: 1,
+      each: 'A',
       exhausted: 'x',
       amount: 100,
       note: '',
@@ -136,6 +143,8 @@ describe('bankrolls', () => {
       label: 'B',
       short: 'B',
       people: '2',
+      count: 2,
+      each: 'each of the two',
       exhausted: 'x',
       amount: 500,
       note: '',
@@ -146,6 +155,8 @@ describe('bankrolls', () => {
       label: 'red',
       short: 'red',
       people: 'nobody',
+      count: 0,
+      each: 'nobody',
       exhausted: 'x',
       amount: 500,
       unlimited: true,
@@ -185,6 +196,13 @@ describe('bankrolls', () => {
       const rung = ladder[rungFor(ladder, 0, needed)];
       expect(rung.unlimited || rung.amount >= needed).toBe(true);
     }
+  });
+
+  it('works out which bankroll a shared total must have had open', () => {
+    expect(rungForTotal(ladder, 0)).toBe(0);
+    expect(rungForTotal(ladder, 100)).toBe(0);
+    expect(rungForTotal(ladder, 101)).toBe(1);
+    expect(rungForTotal(ladder, 5000)).toBe(2); // nothing covers it: the red
   });
 
   it('reports the overdraft only once you are past the pot', () => {
@@ -297,6 +315,111 @@ describe('formatting', () => {
   });
 });
 
+describe('money back', () => {
+  it('splits what is left among the people it came from', () => {
+    expect(refund(989_000_000_000, 989)).toBe(1_000_000_000);
+    expect(refund(370_000_000_000, 1)).toBe(370_000_000_000);
+  });
+
+  it('has nothing to hand back when the pot is empty or nobody was billed', () => {
+    expect(refund(0, 989)).toBe(0);
+    expect(refund(-5, 989)).toBe(0);
+    expect(refund(100, 0)).toBe(0);
+  });
+
+  it('leaves every real bankroll able to answer the question', () => {
+    for (const b of bankrolls) {
+      if (b.unlimited) continue;
+      expect(b.count, `${b.id} has no headcount`).toBeGreaterThan(0);
+      expect(b.each.length, `${b.id} has nobody to give it back to`).toBeGreaterThan(2);
+    }
+  });
+});
+
+describe('sharing', () => {
+  it('round-trips a ledger through a link', () => {
+    const funded = { one: 1, yearly: 3 };
+    const code = encodeSpend([oneTime, yearly], funded);
+    expect(code).toBe('one,yearly:3');
+    expect(decodeSpend([oneTime, yearly], code)).toEqual(funded);
+  });
+
+  it('writes ids in catalog order so the same spending makes the same link', () => {
+    const forwards = encodeSpend([oneTime, yearly], { one: 1, yearly: 2 });
+    const backwards = encodeSpend([oneTime, yearly], { yearly: 2, one: 1 });
+    expect(forwards).toBe(backwards);
+  });
+
+  it('drops unfunded items instead of writing zeroes', () => {
+    expect(encodeSpend([oneTime, yearly], { one: 0, yearly: 1 })).toBe('yearly');
+    expect(encodeSpend([oneTime, yearly], {})).toBe('');
+  });
+
+  it('survives links that are empty, stale or nonsense', () => {
+    expect(decodeSpend([oneTime, yearly], null)).toEqual({});
+    expect(decodeSpend([oneTime, yearly], '')).toEqual({});
+    expect(decodeSpend([oneTime, yearly], 'ghost,one')).toEqual({ one: 1 });
+    expect(decodeSpend([oneTime, yearly], 'yearly:nope')).toEqual({});
+    expect(decodeSpend([oneTime, yearly], 'yearly:99')).toEqual({ yearly: 4 });
+  });
+
+  it('lays the receipt out for pasting, with the link at the end', () => {
+    const allocs = receipt(allocations(testTiers, { one: 1, yearly: 4 }));
+    const text = shareText({
+      ledger: allocs,
+      spent: 30_000_000_000,
+      pot: FORTUNE,
+      left: FORTUNE - 30_000_000_000,
+      url: 'https://example.com/trillion?s=one,yearly:4'
+    });
+    expect(text).toContain('I gave away $30B of $1T');
+    expect(text).toContain('$20B · Yearly × 4 years');
+    expect(text).toContain('$10B · One time');
+    expect(text).toContain('$970B still in the pile.');
+    expect(text.endsWith('https://example.com/trillion?s=one,yearly:4')).toBe(true);
+  });
+
+  it('collapses long ledgers instead of pasting all of them', () => {
+    const many = Array.from({ length: 9 }, (_, i) => ({
+      item: { ...oneTime, id: `i${i}`, label: `Item ${i}` },
+      tierId: 'a',
+      units: 1,
+      amount: 10_000_000_000
+    }));
+    const text = shareText({
+      ledger: many,
+      spent: 90_000_000_000,
+      pot: FORTUNE,
+      left: FORTUNE - 90_000_000_000,
+      url: 'https://example.com/trillion',
+      limit: 4
+    });
+    expect(text).toContain('…and 5 more');
+    expect(text).not.toContain('Item 8');
+  });
+
+  it('says so when the money does not exist, or was never spent', () => {
+    const allocs = allocations(testTiers, { one: 1 });
+    expect(
+      shareText({
+        ledger: allocs,
+        spent: 10_000_000_000,
+        pot: 1_000_000_000,
+        left: -9_000_000_000,
+        url: 'u'
+      })
+    ).toContain('Overdrawn by $9B');
+    expect(shareText({ ledger: [], spent: 0, pot: FORTUNE, left: FORTUNE, url: 'u' })).toContain(
+      "haven't spent a cent"
+    );
+  });
+
+  it('round-trips the real catalog', () => {
+    const funded = { painting: 1, homeless: 5, nfl: 1, 'debt-interest': 2 };
+    expect(decodeSpend(allItems, encodeSpend(allItems, funded))).toEqual(funded);
+  });
+});
+
 describe('the catalog', () => {
   it('gives every item a unique id', () => {
     const ids = allItems.map((item) => item.id);
@@ -315,6 +438,12 @@ describe('the catalog', () => {
   it('explains every price', () => {
     for (const item of allItems) {
       expect(item.note.length, `${item.id} has no note`).toBeGreaterThan(20);
+    }
+  });
+
+  it('gives every tier a hue, so a new tier cannot paint blank squares', () => {
+    for (const tier of tiers) {
+      expect(tierColors[tier.id], `${tier.id} has no color`).toMatch(/^oklch\(/);
     }
   });
 

--- a/src/lib/trillion/game.ts
+++ b/src/lib/trillion/game.ts
@@ -47,6 +47,10 @@ export interface Bankroll {
   short: string;
   /** How many people are being emptied out. */
   people: string;
+  /** The same headcount as a number, for the money-back-each math. */
+  count: number;
+  /** Reads after "give": "Elon", "each of America's 989 billionaires". */
+  each: string;
   /**
    * The modal headline when this bankroll runs dry. Written out per rung rather
    * than assembled, because "the top 10 has" and "US billionaires's money" is
@@ -203,6 +207,18 @@ export function nextBankroll(bankrolls: Bankroll[], level: number): Bankroll | u
 }
 
 /**
+ * The cheapest rung that can hold `total`, counting from the bottom. A shared
+ * ledger arrives as a pile of numbers with no history, so this works out which
+ * bankroll the sender must have had open.
+ */
+export function rungForTotal(bankrolls: Bankroll[], total: number): number {
+  for (let i = 0; i < bankrolls.length; i++) {
+    if (bankrolls[i].unlimited || bankrolls[i].amount >= total) return i;
+  }
+  return bankrolls.length - 1;
+}
+
+/**
  * The lowest rung that actually covers `needed` (total committed after the
  * purchase), or the last rung if nothing does. Offering merely the next rung up
  * would let you accept an upgrade and still land in the red — buying a $5.3T
@@ -238,4 +254,86 @@ export function overdraft(spent: number, pot: number): number {
 /** Everything you funded, cheapest last — the receipt reads better big-first. */
 export function receipt(allocs: Allocation[]): Allocation[] {
   return [...allocs].sort((a, b) => b.amount - a.amount);
+}
+
+/**
+ * What is left over, split back among the people it was taken from. The whole
+ * point of the line it feeds: after buying every fix on the list, everybody you
+ * billed can still be handed a fortune back.
+ */
+export function refund(left: number, count: number): number {
+  if (left <= 0 || count <= 0) return 0;
+  return left / count;
+}
+
+/**
+ * A ledger as a query string: `painting,homeless:5,nfl`. Ids are written in
+ * catalog order so the same spending always produces the same link, and years
+ * are only spelled out when there is more than one.
+ */
+export function encodeSpend(items: Item[], funded: Funded): string {
+  return items
+    .map((item) => ({ item, units: clampUnits(item, funded[item.id] ?? 0) }))
+    .filter(({ units }) => units > 0)
+    .map(({ item, units }) => (units > 1 ? `${item.id}:${units}` : item.id))
+    .join(',');
+}
+
+/**
+ * The other direction. Anything that is not a live item id is dropped, so an
+ * old link keeps working after the catalog changes instead of erroring.
+ */
+export function decodeSpend(items: Item[], code: string | null | undefined): Funded {
+  if (!code) return {};
+  const byId = new Map(items.map((item) => [item.id, item]));
+  const funded: Funded = {};
+  for (const part of code.split(',')) {
+    const [id, years] = part.split(':');
+    const item = byId.get(id);
+    if (!item) continue;
+    const units = clampUnits(item, years === undefined ? 1 : Number(years));
+    if (units > 0) funded[item.id] = units;
+  }
+  return funded;
+}
+
+export interface ShareArgs {
+  ledger: Allocation[];
+  spent: number;
+  pot: number;
+  left: number;
+  url: string;
+  /** Lines to print before the rest get collapsed into a count. */
+  limit?: number;
+}
+
+/**
+ * The receipt as something you can paste anywhere. Long ledgers get truncated
+ * rather than pasted in full: the top few lines are the priorities, which is
+ * the part worth sharing.
+ */
+export function shareText({ ledger, spent, pot, left, url, limit = 6 }: ShareArgs): string {
+  if (ledger.length === 0) {
+    return `A trillion dollars to give away and I haven't spent a cent of it.\n\n${url}`;
+  }
+
+  const lines = ledger
+    .slice(0, limit)
+    .map(
+      (alloc) =>
+        `${formatMoney(alloc.amount)} · ${alloc.item.label}${
+          alloc.units > 1 ? ` × ${alloc.units} years` : ''
+        }`
+    );
+  const rest = ledger.length - lines.length;
+  if (rest > 0) lines.push(`…and ${rest} more`);
+
+  const tail =
+    left >= 0
+      ? `${formatMoney(left)} still in the pile.`
+      : `Overdrawn by ${formatMoney(-left)} — that money does not exist.`;
+
+  return `I gave away ${formatMoney(spent)} of ${formatMoney(pot)}:\n\n${lines.join(
+    '\n'
+  )}\n\n${tail}\n\nSpend yours: ${url}`;
 }

--- a/src/lib/trillion/items.ts
+++ b/src/lib/trillion/items.ts
@@ -158,18 +158,6 @@ export const tiers: Tier[] = [
             url: 'https://en.wikipedia.org/wiki/Shohei_Ohtani'
           }
         ]
-      },
-      {
-        id: 'tesla-bonus',
-        label: 'A $50,000 bonus for every Tesla employee',
-        cost: 6_739_250_000,
-        note: 'Tesla reported 134,785 employees worldwide at the end of 2025. At $50,000 each that is $6.74 billion — three and a half times the painting, the car, the yacht and the contract put together.',
-        sources: [
-          {
-            label: 'Tesla FY2025 Form 10-K',
-            url: 'https://www.sec.gov/Archives/edgar/data/1318605/000162828026003952/tsla-20251231.htm'
-          }
-        ]
       }
     ]
   },
@@ -242,18 +230,6 @@ export const tiers: Tier[] = [
           {
             label: 'Gavi 2026–2030',
             url: 'https://www.gavi.org/news/media-room/protecting-more-children-gavi-vaccine-alliance-plans-next-5-year-period'
-          }
-        ]
-      },
-      {
-        id: 'lead-pipes',
-        label: 'Rip out every lead pipe in America',
-        cost: 18_800_000_000,
-        note: 'The EPA counts about 4 million lead service lines still in the ground at an average replacement cost of $4,700 each.',
-        sources: [
-          {
-            label: 'Brookings on EPA estimates',
-            url: 'https://www.brookings.edu/articles/what-would-it-cost-to-replace-all-the-nations-lead-water-pipes/'
           }
         ]
       },
@@ -343,7 +319,7 @@ export const tiers: Tier[] = [
     id: 'country',
     title: 'One country',
     kicker: 'Tier four',
-    lede: 'Back to work. These are the line items of a single nation — the ones that show up in budget fights every year.',
+    lede: 'Back to work. These are the line items of a single nation: four programs that come up for renewal every year, then two things the country has been arguing about building for a decade.',
     items: [
       {
         id: 'school-meals',
@@ -379,6 +355,20 @@ export const tiers: Tier[] = [
         ]
       },
       {
+        id: 'usaid',
+        label: 'Cover the entire USAID budget',
+        cost: 40_000_000_000,
+        per: 'year',
+        maxUnits: 25,
+        note: 'Congress appropriated roughly $39.6 billion for foreign assistance managed by USAID and the State Department in FY2024, the agency’s last full year before it was folded into State. Every year you fund here is one full year of that work.',
+        sources: [
+          {
+            label: 'CRS: USAID overview',
+            url: 'https://www.congress.gov/crs-product/IF10261'
+          }
+        ]
+      },
+      {
         id: 'nih',
         label: 'Run the entire NIH for a year',
         cost: 47_000_000_000,
@@ -393,33 +383,6 @@ export const tiers: Tier[] = [
         ]
       },
       {
-        id: 'bridges',
-        label: 'Repair every deficient bridge in America',
-        cost: 467_000_000_000,
-        note: 'ARTBA counts 42,067 US bridges rated in poor condition, with an estimated $467 billion repair bill. One in three bridges needs work.',
-        sources: [{ label: 'ARTBA Bridge Report', url: 'https://artbabridgereport.org/' }]
-      },
-      {
-        id: 'interstate',
-        label: 'Build the Interstate Highway System from scratch',
-        cost: 500_000_000_000,
-        note: 'Almost 48,000 miles, finished in 1992 at $129 billion of the day’s money — north of half a trillion in today’s.',
-        sources: [
-          {
-            label: 'FHWA highway history',
-            url: 'https://www.fhwa.dot.gov/highwayhistory/data/page03.cfm'
-          }
-        ]
-      }
-    ]
-  },
-  {
-    id: 'commons',
-    title: 'The commons',
-    kicker: 'Tier five',
-    lede: 'The shared plumbing: the things nobody owns, everybody uses, and no single buyer has ever had the balance sheet to fix. Every item in this tier put together still fits inside the fortune.',
-    items: [
-      {
         id: 'broadband',
         label: 'High-speed internet to every American home',
         cost: 42_450_000_000,
@@ -428,6 +391,42 @@ export const tiers: Tier[] = [
           {
             label: 'NTIA BEAD program',
             url: 'https://www.ntia.gov/funding-programs/high-speed-internet-programs/broadband-equity-access-and-deployment-bead-program'
+          }
+        ]
+      },
+      {
+        id: 'hsr',
+        label: 'Build high-speed rail across America',
+        cost: 205_000_000_000,
+        note: 'The American High-Speed Rail Act asks for $41 billion a year for five years — $205 billion — for corridor construction, planning and safety rules for a national network. The ask has never been appropriated.',
+        sources: [
+          {
+            label: 'High Speed Rail Alliance',
+            url: 'https://www.hsrail.org/blog/205b-american-high-speed-rail-act-introduced/'
+          },
+          {
+            label: 'Sponsor’s summary',
+            url: 'https://moulton.house.gov/news/press-releases/moulton-re-introduces-american-high-speed-rail-act-calling-41-billion-annual'
+          }
+        ]
+      }
+    ]
+  },
+  {
+    id: 'repairs',
+    title: 'The repair bill',
+    kicker: 'Tier five',
+    lede: 'Nothing new gets built in this tier. This is the tab for what America already built and then stopped maintaining — pipes, bridges, locks, rail — where the price is a bill that grows every year nobody pays it. All four of these together still fit inside the fortune.',
+    items: [
+      {
+        id: 'lead-pipes',
+        label: 'Rip out every lead pipe in America',
+        cost: 18_800_000_000,
+        note: 'The EPA counts about 4 million lead service lines still in the ground at an average replacement cost of $4,700 each.',
+        sources: [
+          {
+            label: 'Brookings on EPA estimates',
+            url: 'https://www.brookings.edu/articles/what-would-it-cost-to-replace-all-the-nations-lead-water-pipes/'
           }
         ]
       },
@@ -460,36 +459,11 @@ export const tiers: Tier[] = [
         ]
       },
       {
-        id: 'hsr',
-        label: 'Build high-speed rail across America',
-        cost: 205_000_000_000,
-        note: 'The American High-Speed Rail Act asks for $41 billion a year for five years — $205 billion — for corridor construction, planning and safety rules for a national network. The ask has never been appropriated.',
-        sources: [
-          {
-            label: 'High Speed Rail Alliance',
-            url: 'https://www.hsrail.org/blog/205b-american-high-speed-rail-act-introduced/'
-          },
-          {
-            label: 'Sponsor’s summary',
-            url: 'https://moulton.house.gov/news/press-releases/moulton-re-introduces-american-high-speed-rail-act-calling-41-billion-annual'
-          }
-        ]
-      },
-      {
-        id: 'storage',
-        label: 'Put a terawatt-hour of batteries on the grid',
-        cost: 334_000_000_000,
-        note: 'NREL benchmarks four-hour utility-scale lithium-ion storage at $334 per kilowatt-hour, so a terawatt-hour — a thousand gigawatt-hours, enough to hold the output of a thousand large power plants for an hour — runs $334 billion. America’s record year, 2025, added 58 gigawatt-hours. This is seventeen of those, at once.',
-        sources: [
-          {
-            label: 'NREL storage cost projections, 2025',
-            url: 'https://www.osti.gov/biblio/2583471'
-          },
-          {
-            label: 'SEIA: 2025 storage installations',
-            url: 'https://seia.org/news/united-states-installs-58-gwh-of-new-energy-storage-in-2025/'
-          }
-        ]
+        id: 'bridges',
+        label: 'Repair every deficient bridge in America',
+        cost: 467_000_000_000,
+        note: 'ARTBA counts 42,067 US bridges rated in poor condition, with an estimated $467 billion repair bill. One in three bridges needs work.',
+        sources: [{ label: 'ARTBA Bridge Report', url: 'https://artbabridgereport.org/' }]
       }
     ]
   },
@@ -524,20 +498,6 @@ export const tiers: Tier[] = [
           {
             label: 'Ceres2030 / IISD',
             url: 'https://www.iisd.org/articles/iisd-news/ending-world-hunger-2030-would-cost-330bn-study-finds'
-          }
-        ]
-      },
-      {
-        id: 'usaid',
-        label: 'Cover the entire USAID budget',
-        cost: 40_000_000_000,
-        per: 'year',
-        maxUnits: 25,
-        note: 'Congress appropriated roughly $39.6 billion for foreign assistance managed by USAID and the State Department in FY2024, the agency’s last full year before it was folded into State. Every year you fund here is one full year of that work.',
-        sources: [
-          {
-            label: 'CRS: USAID overview',
-            url: 'https://www.congress.gov/crs-product/IF10261'
           }
         ]
       },
@@ -617,7 +577,7 @@ export const tiers: Tier[] = [
     id: 'moonshots',
     title: 'Moonshots',
     kicker: 'Tier seven',
-    lede: 'Fine. Buy the biggest things our species has ever attempted.',
+    lede: 'Fine. The biggest things our species has ever attempted: two we actually finished, then the machine that would have to replace the power plants — generation, and somewhere to put it until the evening.',
     items: [
       {
         id: 'apollo',
@@ -632,6 +592,18 @@ export const tiers: Tier[] = [
         ]
       },
       {
+        id: 'interstate',
+        label: 'Build the Interstate Highway System from scratch',
+        cost: 500_000_000_000,
+        note: 'Almost 48,000 miles, finished in 1992 at $129 billion of the day’s money — north of half a trillion in today’s. The largest public works project in American history, and the one everybody drives on without thinking about it.',
+        sources: [
+          {
+            label: 'FHWA highway history',
+            url: 'https://www.fhwa.dot.gov/highwayhistory/data/page03.cfm'
+          }
+        ]
+      },
+      {
         id: 'nuclear',
         label: 'Build ten Vogtle-sized nuclear plants',
         cost: 315_000_000_000,
@@ -640,6 +612,22 @@ export const tiers: Tier[] = [
           {
             label: 'Lazard LCOE+ 2025',
             url: 'https://www.lazard.com/media/eijnqja3/lazards-lcoeplus-june-2025.pdf'
+          }
+        ]
+      },
+      {
+        id: 'storage',
+        label: 'Put a terawatt-hour of batteries on the grid',
+        cost: 334_000_000_000,
+        note: 'NREL benchmarks four-hour utility-scale lithium-ion storage at $334 per kilowatt-hour, so a terawatt-hour — a thousand gigawatt-hours, enough to hold an hour of output from a thousand large power plants — runs $334 billion. America’s record year, 2025, added 58 gigawatt-hours. This is seventeen of those, at once, and it is what makes the solar below worth building.',
+        sources: [
+          {
+            label: 'NREL storage cost projections, 2025',
+            url: 'https://www.osti.gov/biblio/2583471'
+          },
+          {
+            label: 'SEIA: 2025 storage installations',
+            url: 'https://seia.org/news/united-states-installs-58-gwh-of-new-energy-storage-in-2025/'
           }
         ]
       },
@@ -661,8 +649,20 @@ export const tiers: Tier[] = [
     id: 'money',
     title: 'Just move the money',
     kicker: 'Tier eight',
-    lede: 'Nothing to build here and nobody to hire. These are numbers that already exist somewhere in the economy, moved from one column into another — which turns out to be the most expensive thing on the board.',
+    lede: 'Nothing to build here, nothing to dig up, nobody new to hire. These are transfers: numbers that already exist somewhere in the economy, moved from one column into another. The cheapest one is the most personal, and the last one is a bill the country is already paying.',
     items: [
+      {
+        id: 'tesla-bonus',
+        label: 'A $50,000 bonus for every Tesla employee',
+        cost: 6_739_250_000,
+        note: 'Tesla reported 134,785 employees worldwide at the end of 2025. At $50,000 each that is $6.74 billion — three and a half times the painting, the car, the yacht and the record contract put together, and the smallest transfer on this list.',
+        sources: [
+          {
+            label: 'Tesla FY2025 Form 10-K',
+            url: 'https://www.sec.gov/Archives/edgar/data/1318605/000162828026003952/tsla-20251231.htm'
+          }
+        ]
+      },
       {
         id: 'tariffs',
         label: 'Refund every tariff Americans paid in 2025',
@@ -716,6 +716,23 @@ export const tiers: Tier[] = [
             url: 'https://www.crfb.org/blogs/net-interest-costs-will-double-again-over-next-decade'
           }
         ]
+      }
+    ]
+  },
+  {
+    id: 'wall',
+    title: 'The wall',
+    kicker: 'Tier nine',
+    lede: 'And here is the other edge of it. These are the numbers that do not care how rich anyone is: what households owe, what a country owes itself, and what a year of running things actually costs.',
+    items: [
+      {
+        id: 'everyone',
+        label: 'Hand every person on Earth $120',
+        cost: 996_000_000_000,
+        note: 'There are about 8.3 billion of us. Split the entire fortune evenly and everyone alive gets $120 — one tank of gas, one week of groceries. That is what a trillion dollars is, spread across the species.',
+        sources: [
+          { label: 'World population', url: 'https://www.worldometers.info/world-population/' }
+        ]
       },
       {
         id: 'credit-cards',
@@ -727,23 +744,6 @@ export const tiers: Tier[] = [
             label: 'NY Fed household debt, Q2 2026',
             url: 'https://www.newyorkfed.org/newsevents/news/research/2026/20260811'
           }
-        ]
-      }
-    ]
-  },
-  {
-    id: 'wall',
-    title: 'The wall',
-    kicker: 'Tier nine',
-    lede: 'And here is the other edge of it. These are the numbers that do not care how rich anyone is.',
-    items: [
-      {
-        id: 'everyone',
-        label: 'Hand every person on Earth $120',
-        cost: 996_000_000_000,
-        note: 'There are about 8.3 billion of us. Split the entire fortune evenly and everyone alive gets $120 — one tank of gas, one week of groceries. That is what a trillion dollars is, spread across the species.',
-        sources: [
-          { label: 'World population', url: 'https://www.worldometers.info/world-population/' }
         ]
       },
       {
@@ -762,7 +762,7 @@ export const tiers: Tier[] = [
         id: 'infra-gap',
         label: 'Fix everything in America at once',
         cost: 3_700_000_000_000,
-        note: 'ASCE prices a state of good repair across all eighteen categories it grades — roads, bridges, dams, levees, the grid, drinking water, transit, ports — at $9.1 trillion through 2033. Current funding trends cover $5.4 trillion of that. The hole is $3.7 trillion.',
+        note: 'ASCE prices a state of good repair across all eighteen categories it grades — roads, bridges, dams, levees, the grid, drinking water, transit, ports — at $9.1 trillion through 2033. Current funding trends cover $5.4 trillion of that. The hole is $3.7 trillion, and the pipes, ports, transit and bridges you were offered earlier are four line items inside it.',
         sources: [
           {
             label: 'ASCE 2025 Report Card',
@@ -811,7 +811,7 @@ export const tierColors: Record<string, string> = {
   cheap: 'oklch(0.72 0.13 160)',
   trophies: 'oklch(0.70 0.13 305)',
   country: 'oklch(0.70 0.12 250)',
-  commons: 'oklch(0.73 0.13 122)',
+  repairs: 'oklch(0.73 0.13 122)',
   planet: 'oklch(0.74 0.11 195)',
   moonshots: 'oklch(0.68 0.15 30)',
   money: 'oklch(0.70 0.13 345)',

--- a/src/lib/trillion/items.ts
+++ b/src/lib/trillion/items.ts
@@ -26,6 +26,8 @@ export const bankrolls: Bankroll[] = [
     label: 'Elon Musk',
     short: 'Elon',
     people: '1 person',
+    count: 1,
+    each: 'Elon',
     exhausted: "That's more than even Elon has.",
     amount: 1_000_000_000_000,
     note: 'In June 2026 he became the first person ever to be worth a trillion dollars, on the back of the SpaceX listing. A round trillion is the starting pot.',
@@ -41,6 +43,8 @@ export const bankrolls: Bankroll[] = [
     label: 'the ten richest people on Earth',
     short: 'the top 10',
     people: '10 people',
+    count: 10,
+    each: 'each of the ten richest people alive',
     exhausted: "That's more than the ten richest people on Earth have.",
     amount: 2_600_000_000_000,
     note: 'Musk, Page, Brin, Bezos, Zuckerberg, Ellison, Arnault, Huang, Buffett, Ortega. Everyone in the top ten is worth over $140 billion; together they hold $2.6 trillion.',
@@ -56,6 +60,8 @@ export const bankrolls: Bankroll[] = [
     label: 'every billionaire in America',
     short: 'US billionaires',
     people: '989 people',
+    count: 989,
+    each: "each of America's 989 billionaires",
     exhausted: "That's more than every billionaire in America has.",
     amount: 8_400_000_000_000,
     note: 'The United States holds 989 billionaires worth $8.4 trillion between them — more than a third of all billionaire wealth on the planet.',
@@ -71,6 +77,8 @@ export const bankrolls: Bankroll[] = [
     label: 'every billionaire on Earth',
     short: 'all billionaires',
     people: '3,428 people',
+    count: 3428,
+    each: "each of the world's 3,428 billionaires",
     exhausted: "That's more than every billionaire on Earth has.",
     amount: 20_100_000_000_000,
     note: 'A record 3,428 billionaires worth a combined $20.1 trillion — a group that got $4 trillion richer in a single year. This is the last real money on the board.',
@@ -86,6 +94,8 @@ export const bankrolls: Bankroll[] = [
     label: 'money that does not exist',
     short: 'the red',
     people: 'nobody',
+    count: 0,
+    each: 'nobody',
     exhausted: 'There is nobody left to bill.',
     amount: 20_100_000_000_000,
     unlimited: true,
@@ -404,9 +414,89 @@ export const tiers: Tier[] = [
     ]
   },
   {
+    id: 'commons',
+    title: 'The commons',
+    kicker: 'Tier five',
+    lede: 'The shared plumbing: the things nobody owns, everybody uses, and no single buyer has ever had the balance sheet to fix. Every item in this tier put together still fits inside the fortune.',
+    items: [
+      {
+        id: 'broadband',
+        label: 'High-speed internet to every American home',
+        cost: 42_450_000_000,
+        note: 'BEAD is the largest federal broadband program ever written: $42.45 billion to wire the 25 million Americans who still have no high-speed service. You are covering the entire program in one payment.',
+        sources: [
+          {
+            label: 'NTIA BEAD program',
+            url: 'https://www.ntia.gov/funding-programs/high-speed-internet-programs/broadband-equity-access-and-deployment-bead-program'
+          }
+        ]
+      },
+      {
+        id: 'ports',
+        label: 'Fix every port, lock and shipping channel in America',
+        cost: 45_000_000_000,
+        note: 'ASCE puts ten years of water transportation needs at about $45 billion — nearly $38 billion of it at the ports themselves, the rest on the inland waterways every barge of grain and gravel has to pass through. Ports graded a B in 2025; the waterways a C−.',
+        sources: [
+          {
+            label: 'ASCE 2025: Ports',
+            url: 'https://infrastructurereportcard.org/cat-item/ports-infrastructure/'
+          },
+          {
+            label: 'ASCE 2025: Inland Waterways',
+            url: 'https://infrastructurereportcard.org/cat-item/inland-waterways-infrastructure/'
+          }
+        ]
+      },
+      {
+        id: 'transit',
+        label: 'Close the repair gap on every bus and train in America',
+        cost: 152_000_000_000,
+        note: 'Transit graded a D. ASCE counts $618 billion of needs through 2033 against $466 billion of expected funding, leaving a $152 billion hole. This is the hole, filled.',
+        sources: [
+          {
+            label: 'ASCE 2025: Transit',
+            url: 'https://infrastructurereportcard.org/cat-item/transit-infrastructure/'
+          }
+        ]
+      },
+      {
+        id: 'hsr',
+        label: 'Build high-speed rail across America',
+        cost: 205_000_000_000,
+        note: 'The American High-Speed Rail Act asks for $41 billion a year for five years — $205 billion — for corridor construction, planning and safety rules for a national network. The ask has never been appropriated.',
+        sources: [
+          {
+            label: 'High Speed Rail Alliance',
+            url: 'https://www.hsrail.org/blog/205b-american-high-speed-rail-act-introduced/'
+          },
+          {
+            label: 'Sponsor’s summary',
+            url: 'https://moulton.house.gov/news/press-releases/moulton-re-introduces-american-high-speed-rail-act-calling-41-billion-annual'
+          }
+        ]
+      },
+      {
+        id: 'storage',
+        label: 'Put a terawatt-hour of batteries on the grid',
+        cost: 334_000_000_000,
+        note: 'NREL benchmarks four-hour utility-scale lithium-ion storage at $334 per kilowatt-hour, so a terawatt-hour — a thousand gigawatt-hours, enough to hold the output of a thousand large power plants for an hour — runs $334 billion. America’s record year, 2025, added 58 gigawatt-hours. This is seventeen of those, at once.',
+        sources: [
+          {
+            label: 'NREL storage cost projections, 2025',
+            url: 'https://www.osti.gov/biblio/2583471'
+          },
+          {
+            label: 'SEIA: 2025 storage installations',
+            url: 'https://seia.org/news/united-states-installs-58-gwh-of-new-energy-storage-in-2025/'
+          }
+        ]
+      }
+    ]
+  },
+  {
     id: 'planet',
     title: 'One planet',
-    kicker: 'Tier five',
+    kicker: 'Tier six',
     lede: 'The whole world now, priced by the year. These are the headline numbers of global development — the ones usually described as impossible to raise.',
     items: [
       {
@@ -526,7 +616,7 @@ export const tiers: Tier[] = [
   {
     id: 'moonshots',
     title: 'Moonshots',
-    kicker: 'Tier six',
+    kicker: 'Tier seven',
     lede: 'Fine. Buy the biggest things our species has ever attempted.',
     items: [
       {
@@ -568,9 +658,83 @@ export const tiers: Tier[] = [
     ]
   },
   {
+    id: 'money',
+    title: 'Just move the money',
+    kicker: 'Tier eight',
+    lede: 'Nothing to build here and nobody to hire. These are numbers that already exist somewhere in the economy, moved from one column into another — which turns out to be the most expensive thing on the board.',
+    items: [
+      {
+        id: 'tariffs',
+        label: 'Refund every tariff Americans paid in 2025',
+        cost: 287_000_000_000,
+        note: 'Daily Treasury data has $287 billion in customs duties, taxes and fees collected in calendar 2025, up 192% in a single year. US importers write those checks, and most of the cost turns up downstream in prices. This hands the whole year back.',
+        sources: [
+          {
+            label: 'Richmond Fed on Treasury data',
+            url: 'https://www.richmondfed.org/research/national_economy/macro_minute/2026/how_much_revenue_raised_by_tariffs_so_far'
+          }
+        ]
+      },
+      {
+        id: 'small-business',
+        label: 'Triple the number of American businesses that have employees',
+        cost: 315_000_000_000,
+        note: 'The SBA counts 6.3 million small businesses with anyone at all on the payroll, out of 36.2 million total. A $25,000 launch grant for 12.6 million more — three times as many employers as the country has now — is $315 billion.',
+        sources: [
+          {
+            label: 'SBA Office of Advocacy, 2025',
+            url: 'https://advocacy.sba.gov/2025/06/30/new-advocacy-report-shows-the-number-of-small-businesses-in-the-u-s-exceeds-36-million/'
+          }
+        ]
+      },
+      {
+        id: 'dividend',
+        label: 'Send every American a $2,000 check',
+        cost: 600_000_000_000,
+        note: 'One round of $2,000 per person — adults and children, the way the pandemic payments were written — costs about $600 billion, roughly twice what a year of the new tariffs brings in. Three fifths of the fortune, gone in one mailing.',
+        sources: [
+          {
+            label: 'CRFB estimate',
+            url: 'https://www.crfb.org/blogs/tariff-dividends-could-cost-600-billion-year'
+          }
+        ]
+      },
+      {
+        id: 'debt-interest',
+        label: 'Cover a year of interest on the national debt',
+        cost: 970_000_000_000,
+        per: 'year',
+        maxUnits: 5,
+        note: 'The federal government paid $970 billion in interest in FY2025 — up $89 billion in a year, and the third-largest line in the budget behind Social Security and Medicare. One year of it is almost exactly the fortune you started with.',
+        sources: [
+          {
+            label: 'Peterson Foundation tracker',
+            url: 'https://www.pgpf.org/programs-and-projects/fiscal-policy/monthly-interest-tracker-national-debt/'
+          },
+          {
+            label: 'CRFB on interest costs',
+            url: 'https://www.crfb.org/blogs/net-interest-costs-will-double-again-over-next-decade'
+          }
+        ]
+      },
+      {
+        id: 'credit-cards',
+        label: 'Erase every credit card balance in America',
+        cost: 1_260_000_000_000,
+        note: 'The New York Fed put card balances at $1.26 trillion in June 2026, just under the record set six months earlier. Clearing all of it costs more than the whole fortune — one household bill, larger than a trillion dollars.',
+        sources: [
+          {
+            label: 'NY Fed household debt, Q2 2026',
+            url: 'https://www.newyorkfed.org/newsevents/news/research/2026/20260811'
+          }
+        ]
+      }
+    ]
+  },
+  {
     id: 'wall',
     title: 'The wall',
-    kicker: 'Tier seven',
+    kicker: 'Tier nine',
     lede: 'And here is the other edge of it. These are the numbers that do not care how rich anyone is.',
     items: [
       {
@@ -591,6 +755,18 @@ export const tiers: Tier[] = [
           {
             label: 'Federal Reserve G.19',
             url: 'https://www.federalreserve.gov/releases/g19/current/'
+          }
+        ]
+      },
+      {
+        id: 'infra-gap',
+        label: 'Fix everything in America at once',
+        cost: 3_700_000_000_000,
+        note: 'ASCE prices a state of good repair across all eighteen categories it grades — roads, bridges, dams, levees, the grid, drinking water, transit, ports — at $9.1 trillion through 2033. Current funding trends cover $5.4 trillion of that. The hole is $3.7 trillion.',
+        sources: [
+          {
+            label: 'ASCE 2025 Report Card',
+            url: 'https://infrastructurereportcard.org/making-the-grade/'
           }
         ]
       },
@@ -624,3 +800,20 @@ export const tiers: Tier[] = [
 
 /** Every item, flat, in page order. */
 export const allItems = tiers.flatMap((tier) => tier.items);
+
+/**
+ * One hue per tier at mid lightness, so the same value works as a grid square
+ * and as a card's edge on either theme. Lives next to the tiers because a tier
+ * added without a color paints nothing at all in the hero grid.
+ */
+export const tierColors: Record<string, string> = {
+  toys: 'oklch(0.74 0.12 85)',
+  cheap: 'oklch(0.72 0.13 160)',
+  trophies: 'oklch(0.70 0.13 305)',
+  country: 'oklch(0.70 0.12 250)',
+  commons: 'oklch(0.73 0.13 122)',
+  planet: 'oklch(0.74 0.11 195)',
+  moonshots: 'oklch(0.68 0.15 30)',
+  money: 'oklch(0.70 0.13 345)',
+  wall: 'oklch(0.62 0.03 264)'
+};

--- a/src/routes/trillion/+page.svelte
+++ b/src/routes/trillion/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+  import { replaceState } from '$app/navigation';
+  import { resolve } from '$app/paths';
   import Breadcrumbs from '$lib/components/Breadcrumbs.svelte';
-  import { allItems, bankrolls, tiers } from '$lib/trillion/items';
+  import { allItems, bankrolls, tierColors, tiers } from '$lib/trillion/items';
   import {
     allocations,
     bankrollAt,
@@ -8,6 +10,8 @@
     blockValue,
     canAfford,
     clampUnits,
+    decodeSpend,
+    encodeSpend,
     formatExact,
     formatMoney,
     formatShare,
@@ -15,26 +19,19 @@
     maxUnits,
     needsUpgrade,
     overdraft,
+    refund,
     rungFor,
+    rungForTotal,
     receipt,
+    shareText,
     shortfall,
     spentFraction,
+    totalSpent,
     type Item,
     type Tier
   } from '$lib/trillion/game';
 
   const STORAGE_KEY = 'trillion-game';
-
-  /** One hue per tier, mid-lightness so it reads on both themes. */
-  const TIER_COLOR: Record<string, string> = {
-    toys: 'oklch(0.74 0.12 85)',
-    cheap: 'oklch(0.72 0.13 160)',
-    trophies: 'oklch(0.70 0.13 305)',
-    country: 'oklch(0.70 0.12 250)',
-    planet: 'oklch(0.74 0.11 195)',
-    moonshots: 'oklch(0.68 0.15 30)',
-    wall: 'oklch(0.62 0.03 264)'
-  };
 
   interface Saved {
     funded: Record<string, number>;
@@ -43,20 +40,42 @@
     level: number;
   }
 
-  const DEFAULTS: Saved = { funded: {}, revealed: 1, level: 0 };
+  /** A restored board, plus whether it came off somebody else's shared link. */
+  type Restored = Saved & { borrowed: boolean };
+
+  const DEFAULTS: Restored = { funded: {}, revealed: 1, level: 0, borrowed: false };
+
+  /**
+   * A shared ledger beats a saved one: someone followed a link to see a
+   * particular split, so show them that split, with every tier open — they are
+   * arriving at a finished receipt rather than starting a game.
+   */
+  function fromLink(): Restored | null {
+    const shared = decodeSpend(allItems, new URLSearchParams(window.location.search).get('s'));
+    if (Object.keys(shared).length === 0) return null;
+    return {
+      funded: shared,
+      revealed: tiers.length,
+      level: rungForTotal(bankrolls, totalSpent(tiers, shared)),
+      borrowed: true
+    };
+  }
 
   // Restored at init like the other calculators on this site, so a reload
   // doesn't wipe out a ledger someone spent ten minutes building.
-  function restore(): Saved {
+  function restore(): Restored {
     if (typeof window === 'undefined') return DEFAULTS;
     try {
+      const shared = fromLink();
+      if (shared) return shared;
       const raw = localStorage.getItem(STORAGE_KEY);
       if (!raw) return DEFAULTS;
       const parsed = JSON.parse(raw) as Partial<Saved>;
       return {
         funded: parsed.funded ?? {},
         revealed: Math.min(Math.max(parsed.revealed ?? 1, 1), tiers.length),
-        level: Math.min(Math.max(parsed.level ?? 0, 0), bankrolls.length - 1)
+        level: Math.min(Math.max(parsed.level ?? 0, 0), bankrolls.length - 1),
+        borrowed: false
       };
     } catch {
       return DEFAULTS;
@@ -68,10 +87,18 @@
   let funded = $state<Record<string, number>>(initial.funded);
   let revealed = $state(initial.revealed);
   let level = $state(initial.level);
+  /** Somebody else's ledger, on loan until this visitor changes something. */
+  let borrowed = $state(initial.borrowed);
 
   /** The item waiting on an upgrade, and how many years of it. Drives the modal. */
   let pending = $state<{ item: Item; units: number; tierIndex: number } | null>(null);
   let modal = $state<HTMLDialogElement | null>(null);
+
+  let sheet = $state<HTMLDialogElement | null>(null);
+  let sheetOpen = $state(false);
+  /** Which button just copied something, so it can say so for a moment. */
+  let copied = $state<'text' | 'link' | null>(null);
+  let copyTimer: ReturnType<typeof setTimeout> | undefined;
 
   const bankroll = $derived(bankrollAt(bankrolls, level));
   const pot = $derived(bankroll.amount);
@@ -108,6 +135,10 @@
 
   $effect(() => {
     const saved: Saved = { funded, revealed, level };
+    // Reading the board first keeps this subscribed while the ledger is on loan
+    // from a shared link. Nothing is written until the visitor makes it theirs,
+    // so following somebody's link cannot overwrite their own spending.
+    if (borrowed) return;
     try {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(saved));
     } catch {
@@ -150,7 +181,18 @@
     revealNext(tierIndex);
   }
 
+  /**
+   * The first change to a borrowed ledger makes it this visitor's own: it starts
+   * saving, and the sender's code comes off the URL so a reload keeps the edits.
+   */
+  function claim() {
+    if (!borrowed) return;
+    borrowed = false;
+    replaceState(resolve('/trillion'), {});
+  }
+
   function toggle(item: Item, tierIndex: number) {
+    claim();
     if (isFunded(item)) {
       const { [item.id]: _dropped, ...rest } = funded;
       funded = rest;
@@ -160,6 +202,7 @@
   }
 
   function bump(item: Item, delta: number, tierIndex: number) {
+    claim();
     const next = clampUnits(item, units(item) + delta);
     if (next === 0) {
       const { [item.id]: _dropped, ...rest } = funded;
@@ -171,6 +214,7 @@
 
   /** Take the bankroll the purchase needs and put it through. */
   function acceptUpgrade() {
+    claim();
     level = Math.min(Math.max(upgradeLevel, level), bankrolls.length - 1);
     if (pending) {
       funded = { ...funded, [pending.item.id]: pending.units };
@@ -185,11 +229,69 @@
   }
 
   function reset() {
+    claim();
     funded = {};
     revealed = 1;
     level = 0;
     closeModal();
+    hideSheet();
     window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  /* ---- The receipt sheet ------------------------------------------------- */
+
+  function showSheet() {
+    copied = null;
+    sheet?.showModal();
+    sheetOpen = true;
+  }
+
+  function hideSheet() {
+    sheet?.close();
+  }
+
+  /** Clicks land on the dialog itself only when they land on the backdrop. */
+  function backdropClick(event: MouseEvent) {
+    if (event.target === sheet) hideSheet();
+  }
+
+  /** The page, plus this ledger, so a link opens somebody else's priorities. */
+  function shareUrl(): string {
+    const code = encodeSpend(allItems, funded);
+    const base = `${window.location.origin}${resolve('/trillion')}`;
+    return code ? `${base}?s=${code}` : base;
+  }
+
+  function flash(which: 'text' | 'link') {
+    copied = which;
+    clearTimeout(copyTimer);
+    copyTimer = setTimeout(() => (copied = null), 2200);
+  }
+
+  async function copyToClipboard(value: string, which: 'text' | 'link') {
+    try {
+      await navigator.clipboard.writeText(value);
+      flash(which);
+    } catch {
+      // No clipboard access. Nothing useful to say about it in the UI.
+    }
+  }
+
+  /**
+   * The native share sheet where there is one — phones, mostly — and the
+   * clipboard everywhere else, so the button does something on every machine.
+   */
+  async function shareReceipt() {
+    const text = shareText({ ledger, spent, pot, left, url: shareUrl() });
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: "Give Away Elon's Money", text });
+      } catch {
+        // Dismissed the share sheet, or the target refused it. Either way, done.
+      }
+      return;
+    }
+    await copyToClipboard(text, 'text');
   }
 </script>
 
@@ -200,6 +302,65 @@
     content="A trillion dollars, one thousand squares, and a list of real, sourced prices for fixing things. Spend it all and watch how little moves."
   />
 </svelte:head>
+
+<!--
+  The ledger and the two totals, rendered both at the end of the page and inside
+  the share sheet, so the receipt says exactly the same thing in both places.
+-->
+{#snippet receiptBody(empty: string)}
+  {#if ledger.length === 0}
+    <p class="empty">{empty}</p>
+  {:else}
+    <ol class="ledger">
+      {#each ledger as alloc (alloc.item.id)}
+        <li style:--tier={tierColors[alloc.tierId]}>
+          <span class="l-name">
+            <!-- Non-breaking space: a plain one gets trimmed at the block edge. -->
+            {alloc.item.label}{#if alloc.units > 1}<span class="dim"
+                >&nbsp;× {alloc.units} years</span
+              >{/if}
+          </span>
+          <span class="l-amount">{formatMoney(alloc.amount)}</span>
+        </li>
+      {/each}
+    </ol>
+
+    <div class="totals">
+      <div>
+        <span class="t-label">Allocated</span>
+        <span class="t-value">{formatExact(spent)}</span>
+        <span class="t-note"
+          >{formatShare(spent)} of the fortune, across {ledger.length}
+          {ledger.length === 1 ? 'line' : 'lines'}</span
+        >
+      </div>
+      <div>
+        <span class="t-label">{inTheRed > 0 ? 'Overdrawn by' : 'Still in the pile'}</span>
+        <span class="t-value" class:red={inTheRed > 0}>{formatExact(Math.abs(left))}</span>
+        <span class="t-note">
+          {#if inTheRed > 0}
+            Past every billionaire on Earth. This money does not exist.
+          {:else if left <= 0}
+            Gone. Every square is full.
+          {:else if biggestLeft}
+            Still enough for: {biggestLeft.label.toLowerCase()} ({formatMoney(
+              biggestLeft.cost
+            )}{#if biggestLeft.per}/yr{/if})
+          {:else}
+            Not enough left for anything else on this list.
+          {/if}
+        </span>
+        <!-- The kicker: the leftovers, handed back to the people you billed. -->
+        {#if left > 0 && bankroll.count > 0}
+          <span class="t-sub">
+            Enough to give {bankroll.each}
+            {formatMoney(refund(left, bankroll.count))} back.
+          </span>
+        {/if}
+      </div>
+    </div>
+  {/if}
+{/snippet}
 
 <div class="page">
   <Breadcrumbs
@@ -231,7 +392,7 @@
     <figure class="gridwrap">
       <div class="grid" aria-hidden="true">
         {#each owners as owner, i (i)}
-          <span class="blk" style:background={owner ? TIER_COLOR[owner] : undefined}></span>
+          <span class="blk" style:background={owner ? tierColors[owner] : undefined}></span>
         {/each}
       </div>
       <figcaption>
@@ -247,7 +408,7 @@
   </header>
 
   {#each visibleTiers as tier, tierIndex (tier.id)}
-    <section class="tier" style:--tier={TIER_COLOR[tier.id]}>
+    <section class="tier" style:--tier={tierColors[tier.id]}>
       <div class="tier-head">
         <div class="tier-kicker">{tier.kicker}</div>
         <h2>{tier.title}</h2>
@@ -358,51 +519,9 @@
     <section class="finale">
       <h2>The receipt</h2>
 
-      {#if ledger.length === 0}
-        <p class="empty">
-          You haven't spent a dollar yet. The whole trillion is still sitting up there.
-        </p>
-      {:else}
-        <ol class="ledger">
-          {#each ledger as alloc (alloc.item.id)}
-            <li style:--tier={TIER_COLOR[alloc.tierId]}>
-              <span class="l-name">
-                {alloc.item.label}{#if alloc.units > 1}
-                  <span class="dim"> × {alloc.units} years</span>{/if}
-              </span>
-              <span class="l-amount">{formatMoney(alloc.amount)}</span>
-            </li>
-          {/each}
-        </ol>
-
-        <div class="totals">
-          <div>
-            <span class="t-label">Allocated</span>
-            <span class="t-value">{formatExact(spent)}</span>
-            <span class="t-note"
-              >{formatShare(spent)} of the fortune, across {ledger.length}
-              {ledger.length === 1 ? 'line' : 'lines'}</span
-            >
-          </div>
-          <div>
-            <span class="t-label">{inTheRed > 0 ? 'Overdrawn by' : 'Still in the pile'}</span>
-            <span class="t-value" class:red={inTheRed > 0}>{formatExact(Math.abs(left))}</span>
-            <span class="t-note">
-              {#if inTheRed > 0}
-                Past every billionaire on Earth. This money does not exist.
-              {:else if left <= 0}
-                Gone. Every square is full.
-              {:else if biggestLeft}
-                Still enough for: {biggestLeft.label.toLowerCase()} ({formatMoney(
-                  biggestLeft.cost
-                )}{#if biggestLeft.per}/yr{/if})
-              {:else}
-                Not enough left for anything else on this list.
-              {/if}
-            </span>
-          </div>
-        </div>
-      {/if}
+      {@render receiptBody(
+        "You haven't spent a dollar yet. The whole trillion is still sitting up there."
+      )}
 
       <div class="closers">
         <h3>Three ways to hold the number</h3>
@@ -437,9 +556,17 @@
   {/if}
 
   <!-- Sticky rather than fixed: it rides the viewport bottom while you spend,
-       then settles at the end of the page instead of sitting on the footer. -->
+       then settles at the end of the page instead of sitting on the footer.
+       The whole bar is the handle for the receipt — it is the one control that
+       is always on screen, and the running total is what you want to open. -->
   <aside class="hud" aria-live="polite">
-    <div class="hud-inner">
+    <button
+      type="button"
+      class="hud-inner"
+      onclick={showSheet}
+      aria-haspopup="dialog"
+      aria-expanded={sheetOpen}
+    >
       <div class="hud-main">
         <span class="hud-label">{inTheRed > 0 ? 'Overdrawn' : 'Still to spend'}</span>
         <span class="hud-amount" class:red={inTheRed > 0}
@@ -456,10 +583,60 @@
       <div class="hud-meta">
         <span>bankroll: {bankroll.short}</span>
         <span>{ledger.length} funded</span>
+        <span class="hud-cta">Receipt &amp; share ↑</span>
       </div>
-    </div>
+    </button>
   </aside>
 </div>
+
+<!-- Bottom sheet on a phone, a card parked at the bottom edge on a desktop.
+     A <dialog> gives Escape, focus trapping and the top layer; the backdrop
+     click, the grip and the × are all there to make closing obvious. -->
+<dialog
+  bind:this={sheet}
+  class="sheet"
+  aria-label="Your receipt"
+  onclick={backdropClick}
+  onclose={() => {
+    sheetOpen = false;
+    copied = null;
+  }}
+>
+  <div class="sheet-grip" aria-hidden="true"></div>
+
+  <div class="sheet-head">
+    <div>
+      <h2>The receipt</h2>
+      <p class="sheet-sub">
+        {formatExact(spent)} of {formatMoney(pot)} · {ledger.length}
+        {ledger.length === 1 ? 'line' : 'lines'}
+      </p>
+    </div>
+    <button type="button" class="sheet-x" onclick={hideSheet} aria-label="Close the receipt"
+      >×</button
+    >
+  </div>
+
+  <div class="sheet-body">
+    {@render receiptBody('Nothing on it yet. Fund something and it turns up here.')}
+  </div>
+
+  <div class="sheet-foot">
+    <div class="sheet-actions">
+      <button type="button" class="sheet-share" onclick={shareReceipt}>
+        {copied === 'text' ? 'Copied your receipt' : 'Share my receipt'}
+      </button>
+      <button type="button" class="sheet-copy" onclick={() => copyToClipboard(shareUrl(), 'link')}>
+        {copied === 'link' ? 'Link copied' : 'Copy link'}
+      </button>
+      <button type="button" class="sheet-close" onclick={hideSheet}>Close</button>
+    </div>
+    <p class="sheet-note">
+      The link opens this page with your split already loaded, so whoever you send it to sees what
+      you picked — then spends the trillion their own way.
+    </p>
+  </div>
+</dialog>
 
 <!-- Native <dialog> so focus trapping, Escape and the backdrop come for free. -->
 <dialog bind:this={modal} class="ask-modal" onclose={() => (pending = null)}>
@@ -917,6 +1094,13 @@
     font-size: 12.5px;
     color: var(--muted);
   }
+  /* The money-back line: true at every bankroll, and quieter than the total. */
+  .t-sub {
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    line-height: 1.5;
+    color: var(--faint);
+  }
 
   .closers {
     margin-top: 40px;
@@ -977,11 +1161,26 @@
     background: color-mix(in oklch, var(--bg) 92%, transparent);
     backdrop-filter: saturate(1.2) blur(10px);
   }
+  /* A button, but it has to look like the bar it replaced. */
   .hud-inner {
     display: flex;
     flex-direction: column;
     gap: 7px;
+    width: 100%;
+    border: 0;
+    background: transparent;
     padding: 11px 20px calc(11px + env(safe-area-inset-bottom));
+    font: inherit;
+    color: inherit;
+    text-align: left;
+    cursor: pointer;
+  }
+  .hud-inner:hover .hud-cta {
+    color: var(--accent);
+  }
+  .hud-inner:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -3px;
   }
   .hud-main {
     display: flex;
@@ -1028,6 +1227,181 @@
     font-family: var(--font-mono);
     font-size: 10.5px;
     color: var(--faint);
+  }
+  .hud-cta {
+    color: var(--accent);
+  }
+
+  /* ---- The receipt sheet ------------------------------------------------ */
+  /*
+   * Anchored to the bottom edge and animated up from it, the way a share sheet
+   * behaves on a phone. On a desktop it is the same object, floated off the
+   * bottom edge and capped at a readable width, so the interaction is one
+   * thing to learn rather than two.
+   */
+  .sheet {
+    display: none;
+    flex-direction: column;
+    box-sizing: border-box;
+    width: min(660px, 100%);
+    max-width: 100%;
+    max-height: 88svh;
+    margin: auto auto 0;
+    border: 1px solid var(--border);
+    border-bottom: 0;
+    border-radius: 16px 16px 0 0;
+    background: var(--bg);
+    padding: 0;
+    color: var(--text);
+    opacity: 0;
+    transform: translateY(101%);
+    transition:
+      transform 300ms cubic-bezier(0.22, 1, 0.36, 1),
+      opacity 200ms ease,
+      overlay 300ms allow-discrete,
+      display 300ms allow-discrete;
+  }
+  .sheet[open] {
+    display: flex;
+    opacity: 1;
+    transform: translateY(0);
+  }
+  @starting-style {
+    .sheet[open] {
+      opacity: 0;
+      transform: translateY(101%);
+    }
+  }
+  .sheet::backdrop {
+    background: oklch(0.12 0.02 264 / 0);
+    transition:
+      background 300ms ease,
+      overlay 300ms allow-discrete,
+      display 300ms allow-discrete;
+  }
+  .sheet[open]::backdrop {
+    background: oklch(0.12 0.02 264 / 0.66);
+    backdrop-filter: blur(3px);
+  }
+  @starting-style {
+    .sheet[open]::backdrop {
+      background: oklch(0.12 0.02 264 / 0);
+    }
+  }
+
+  .sheet-grip {
+    flex: none;
+    width: 44px;
+    height: 4px;
+    margin: 8px auto 0;
+    border-radius: 2px;
+    background: var(--border);
+  }
+  .sheet-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    flex: none;
+    padding: 12px 18px 14px;
+  }
+  .sheet-head h2 {
+    margin: 0;
+    font-family: var(--font-body);
+    font-weight: 600;
+    font-size: 21px;
+    letter-spacing: -0.02em;
+    color: var(--text);
+  }
+  .sheet-sub {
+    margin: 4px 0 0;
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    color: var(--faint);
+  }
+  .sheet-x {
+    flex: none;
+    width: 40px;
+    height: 40px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: transparent;
+    color: var(--muted);
+    font-size: 20px;
+    line-height: 1;
+    cursor: pointer;
+  }
+  .sheet-x:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+  /* The ledger scrolls; the header and the buttons stay put. */
+  .sheet-body {
+    flex: 1;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    padding: 0 18px 4px;
+  }
+  .sheet-foot {
+    flex: none;
+    border-top: 1px solid var(--border);
+    padding: 14px 18px calc(14px + env(safe-area-inset-bottom));
+  }
+  .sheet-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .sheet-share,
+  .sheet-copy,
+  .sheet-close {
+    border-radius: 8px;
+    padding: 12px 16px;
+    font-family: var(--font-mono);
+    font-size: 13px;
+    min-height: 44px;
+    cursor: pointer;
+  }
+  .sheet-share {
+    flex: 1 1 11rem;
+    border: 1px solid var(--accent);
+    background: var(--accent);
+    color: light-dark(oklch(0.99 0 0), oklch(0.16 0.02 264));
+  }
+  .sheet-share:hover {
+    background: color-mix(in oklch, var(--accent) 86%, white);
+  }
+  .sheet-copy,
+  .sheet-close {
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--muted);
+  }
+  .sheet-copy:hover,
+  .sheet-close:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+  .sheet-share:focus-visible,
+  .sheet-copy:focus-visible,
+  .sheet-close:focus-visible,
+  .sheet-x:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+  .sheet-note {
+    margin: 12px 0 0;
+    font-size: 11.5px;
+    line-height: 1.6;
+    color: var(--faint);
+    text-wrap: pretty;
+  }
+  .sheet .empty {
+    margin: 0 0 8px;
+    font-size: 14px;
+  }
+  .sheet .totals {
+    margin-top: 14px;
   }
 
   /* ---- The bigger-bankroll modal --------------------------------------- */
@@ -1201,12 +1575,44 @@
       flex: none;
       gap: 18px;
     }
+    /* Off the bottom edge, so it reads as a panel rather than a browser chrome. */
+    .sheet {
+      margin-bottom: 24px;
+      border-bottom: 1px solid var(--border);
+      border-radius: 16px;
+      max-height: 80svh;
+    }
+    .sheet-grip {
+      display: none;
+    }
+    .sheet-head {
+      padding: 18px 22px 14px;
+    }
+    .sheet-body {
+      padding: 0 22px 4px;
+    }
+    .sheet-foot {
+      padding: 16px 22px;
+    }
   }
 
   @media (prefers-reduced-motion: reduce) {
     .blk,
     .hud-fill {
       transition: none;
+    }
+    /* Keep the discrete transitions so the dialog still leaves the top layer. */
+    .sheet {
+      transition:
+        overlay 1ms allow-discrete,
+        display 1ms allow-discrete;
+      transform: none;
+      opacity: 1;
+    }
+    .sheet::backdrop {
+      transition:
+        overlay 1ms allow-discrete,
+        display 1ms allow-discrete;
     }
   }
 </style>


### PR DESCRIPTION
The receipt is the personal part of that page, so make it reachable and
sendable. The sticky wallet bar is now the handle for it: tapping the running
total opens a bottom sheet — a <dialog> animated up from the bottom edge on a
phone, the same object parked off the bottom edge on a desktop — holding the
full ledger and a share button. Sharing hands over the split itself, both as
pasteable text and as a link that reopens the page with that exact ledger
loaded, so what gets shared is somebody's priorities rather than a URL. A
borrowed ledger stays out of localStorage until the visitor changes something,
at which point it becomes theirs and the sender's code comes off the URL.

Under "still in the pile", a subtext divides what's left by the number of
people being billed: after buying every fix on the list you can still hand
each of the world's 3,428 billionaires $2.65B back, which is the point.

Two new tiers widen the kinds of answers on offer. "The commons" prices the
shared plumbing — ports and inland waterways, the transit repair gap, a
national high-speed rail network, universal broadband, a terawatt-hour of grid
storage — and the whole tier fits inside the fortune. "Just move the money"
prices transfers instead of projects: a refund of every 2025 tariff, launch
grants that triple the number of American employers, a $2,000 check for
everyone, a year of interest on the national debt, every credit card balance in
the country. The wall gains ASCE's $3.7T infrastructure gap.

Every new price links to a published figure, per the rules in items.ts. Tier
hues move next to the tiers so a tier added without one fails a test instead
of painting blank squares.